### PR TITLE
Fix: Throttle history.replaceState and history.pushState

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "svelte-app",
+  "name": "datenauskunftsbegehren.ch",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1360,6 +1360,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/local-access/-/local-access-1.1.0.tgz",
       "integrity": "sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cropperjs": "^1.5.11",
     "date-fns": "^2.20.2",
     "image-capture": "^0.4.0",
+    "lodash-es": "^4.17.21",
     "sirv-cli": "^1.0.0",
     "svelte-select": "^3.17.0"
   }

--- a/src/letter/IdCapture.svelte
+++ b/src/letter/IdCapture.svelte
@@ -3,7 +3,7 @@
   import 'image-capture';
 
   import { tick, onMount, onDestroy } from 'svelte';
-  import { debounce } from '../lib.js'
+  import { debounce } from 'lodash-es';
 
   import { idImages } from '../stores.js'
   import 'cropperjs/dist/cropper.css';
@@ -122,7 +122,7 @@
   }
 
   onMount(() => {
-    const debouncedSetSizes = debounce(setSizes, 300, true)
+    const debouncedSetSizes = debounce(setSizes, 300, {leading: true, trailing: true});
     debouncedSetSizes();
     resizeObserver = new ResizeObserver(() => {
       debouncedSetSizes()

--- a/src/lib.js
+++ b/src/lib.js
@@ -53,18 +53,3 @@ export async function getHash({text, length}) {
   }
   return hashHex;
 }
-
-export function debounce(func, wait, immediate) {
-	var timeout;
-	return function() {
-		var context = this, args = arguments;
-		var later = function() {
-			timeout = null;
-			if (!immediate) func.apply(context, args);
-		};
-		var callNow = immediate && !timeout;
-		clearTimeout(timeout);
-		timeout = setTimeout(later, wait);
-		if (callNow) func.apply(context, args);
-	};
-};

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,24 +1,8 @@
 import { readable, writable, get } from 'svelte/store';
 import {nl2br, br2nl, ab2str} from './lib.js'
+import { throttle } from 'lodash-es';
 import d from './data.js';
 export const data = readable(d)
-
-let lastStep
-
-const currentUserData = getUserDataFromHash()
-export const userData = writable(currentUserData)
-userData.subscribe(val => {
-  // only if the step changes, we want to push a new state to the history
-  // otherwise we are going to replace the state
-  let pushState = false
-  if (val.step) {
-    if (val.step !== lastStep) {
-      lastStep = val.step;
-      pushState = true;
-    }
-  }
-  setUserDataToHash(val, pushState)
-})
 
 window.addEventListener('hashchange', (event) => {
   userData.update(() => {
@@ -38,18 +22,43 @@ function getUserDataFromHash() {
   }
 }
 
-function setUserDataToHash(data, pushState = false) {
+let lastStep
+function setUserDataToHash(data) {
   // we version everything so we can break the data model in the future
   // but still support v1
   data.v = 1
   const hash = encodeURI(JSON.stringify(data))
   const title = `Datenauskunftsbegehren - ${data.step}`;
+
+  // only if the step changes, we want to push a new state to the history
+  // otherwise we are going to replace the state
+  let pushState = false
+  if (data.step) {
+    if (data.step !== lastStep) {
+      lastStep = data.step;
+      pushState = true;
+    }
+  }
+
   if (pushState) {
     window.history.pushState({step: data.step}, title, `#${hash}`)
   } else {
     window.history.replaceState({step: data.step}, title, `#${hash}`)
   }
 }
+
+// Safari throws if replaceState is called more than 100 times in 30s
+// we throttle to update max once per 300ms
+const setUserDataToHashThrottled = throttle(setUserDataToHash, 300, {
+  leading: true,
+  trailing: true
+})
+
+const currentUserData = getUserDataFromHash()
+export const userData = writable(currentUserData)
+userData.subscribe(val => {
+  setUserDataToHashThrottled(val)
+})
 
 export const userAddressHtml = writable(nl2br(currentUserData.address))
 userAddressHtml.subscribe(address => {


### PR DESCRIPTION
# Description
This is another take at fixing https://github.com/DigitaleGesellschaft/Datenauskunftsbegehren/issues/12 than https://github.com/DigitaleGesellschaft/Datenauskunftsbegehren/pull/16.

It uses lodash's throttle to never call `history.replaceState` or `history.pushState` more than 100 times per 30s by throttling it to a maximum of one call per 300ms.

By ensuring a call at the leading and the trailing edge of the throttle phase, all input will make it to the history eventually.

## Changelog
- 🐞 Fix: Safari doesn't fail anymore to go to the letter stage if the user typed fast in input fields before