### PR TITLE
Avoid printing multiple (and wrong) letters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ node_modules/
 
 dist
 
-# Don't commit personal AGENTS.md files
+# Don't commit personal AI Assistant files
 AGENTS.md
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ node_modules/
 /playwright/.cache/
 
 dist
+
+# Don't commit personal AGENTS.md files
+AGENTS.md

--- a/e2e/drucken.spec.ts
+++ b/e2e/drucken.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+
+const baseState = '"name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"';
+
+// Regression: "Brief Auskunftsbegehren" via StepOne desires section set entry='followup' +
+// desire='data_info_request', causing both the main letter and a followup letter to render
+// simultaneously when printing.
+test('Brief Auskunftsbegehren zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+  const url = `#{"v":1,"entry":"followup","desire":"data_info_request","step":"print",${baseState}}`;
+  await page.goto(url);
+
+  const letterSections = page.locator('section[id="letter"]');
+  await expect(letterSections).toHaveCount(1);
+  await expect(letterSections.first()).toContainText('Datenauskunftsbegehren');
+  await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
+});
+
+test('Normaler Brief zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+  const url = `#{"v":1,"step":"print",${baseState}}`;
+  await page.goto(url);
+
+  await expect(page.locator('section[id="letter"]')).toHaveCount(1);
+});
+
+test('Nachfassen ausbleibende Auskunft zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+  const url = `#{"v":1,"entry":"followup","desire":"unanswered","step":"print",${baseState}}`;
+  await page.goto(url);
+
+  const letterSections = page.locator('section[id="letter"]');
+  await expect(letterSections).toHaveCount(1);
+  await expect(letterSections.first()).toContainText('Ausbleibende Auskunft');
+});
+
+test('Nachfassen unvollständige Antwort zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+  const url = `#{"v":1,"entry":"followup","desire":"incomplete_answer","step":"print",${baseState}}`;
+  await page.goto(url);
+
+  const letterSections = page.locator('section[id="letter"]');
+  await expect(letterSections).toHaveCount(1);
+  await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
+  await expect(letterSections.first()).toContainText('Ich gehe davon aus, dass insbesondere folgende Informationen fehlen');
+});
+
+test('Nachfassen Daten korrigieren zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+  const url = `#{"v":1,"entry":"followup","desire":"data_correction","step":"print",${baseState}}`;
+  await page.goto(url);
+
+  const letterSections = page.locator('section[id="letter"]');
+  await expect(letterSections).toHaveCount(1);
+  await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
+  await expect(letterSections.first()).toContainText('Aufgrund Ihrer Auskunft stellte ich fest, dass von Ihnen bearbeitete Personendaten unrichtig sind.');
+});
+
+test('Nachfassen Daten löschen zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+  const url = `#{"v":1,"entry":"followup","desire":"data_deletion","step":"print",${baseState}}`;
+  await page.goto(url);
+
+  const letterSections = page.locator('section[id="letter"]');
+  await expect(letterSections).toHaveCount(1);
+  await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
+  await expect(letterSections.first()).toContainText('Aufgrund Ihrer Auskunft ersuche ich Sie, folgende Personendaten zu löschen:');
+});
+
+test('Brief Auskunftsbegehren via Einstiegsmaske zeigt nur einen Brief', async ({ page }) => {
+  await page.goto('');
+
+  // "Brief Auskunftsbegehren" aus der Desires-Liste in StepOne auswählen
+  const briefButton = page.locator('button', { hasText: 'Brief Auskunftsbegehren' });
+  await briefButton.click();
+
+  // Adressfelder ausfüllen (StepFollowUp)
+  const userNameField = page.locator('input#userName');
+  await userNameField.fill('E2E Person');
+  const userAddressField = page.locator('textarea#userAddress');
+  await userAddressField.fill('E2E Strasse\n1000 E2EOrt');
+  const orgAddressField = page.locator('textarea#orgAddress');
+  await orgAddressField.fill('E2E Empfänger');
+
+  // Brief generieren
+  const generateButton = page.locator('button', { hasText: 'Brief generieren' });
+  await generateButton.click();
+
+  // Nur ein Brief soll sichtbar sein
+  const letterSections = page.locator('section[id="letter"]');
+  await expect(letterSections).toHaveCount(1);
+  await expect(letterSections.first()).toContainText('Datenauskunftsbegehren');
+  await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
+});

--- a/e2e/drucken.spec.ts
+++ b/e2e/drucken.spec.ts
@@ -61,6 +61,18 @@ test('Nachfassen Daten löschen zeigt beim Drucken exakt einen Brief', async ({ 
   await expect(letterSections.first()).toContainText('Aufgrund Ihrer Auskunft ersuche ich Sie, folgende Personendaten zu löschen:');
 });
 
+test('Kurzer Brief erzeugt beim Drucken eine PDF-Seite', async ({ page, browserName }) => {
+  test.skip(browserName !== 'chromium', 'PDF-Generierung nur in Chromium verfügbar');
+
+  const url = `#{"v":1,"entry":"followup","desire":"unanswered","step":"print",${baseState}}`;
+  await page.goto(url);
+
+  const pdf = await page.pdf({ format: 'A4' });
+  // Count PDF pages: each page dictionary has /Type /Page (singular, not /Pages)
+  const pageCount = (pdf.toString('latin1').match(/\/Type\s*\/Page(?!s)/g) || []).length;
+  expect(pageCount).toBe(1);
+});
+
 test('Brief Auskunftsbegehren via Einstiegsmaske zeigt nur einen Brief', async ({ page }) => {
   await page.goto('');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,29 +26,6 @@
         "vite": "^8.0.9"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -449,6 +426,29 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.16",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
@@ -549,6 +549,7 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -577,6 +578,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1251,6 +1253,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1394,6 +1397,7 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.4.tgz",
       "integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1947,6 +1951,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1968,6 +1973,7 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,31 @@
         "vite": "^8.0.9"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -549,7 +574,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -578,7 +602,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1253,7 +1276,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1397,7 +1419,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.4.tgz",
       "integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1951,7 +1972,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1973,7 +1993,6 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -164,17 +164,17 @@
 
   {#if $userData.step && $userData.step !== 'entry'}
     <Share></Share>
-    {#if $userData.step === 'data_info_request' || $userData.step === 'print'}
+    {#if $userData.step === 'data_info_request' || ($userData.step === 'print' && ($userData.entry !== 'followup' || $userData.desire === 'data_info_request'))}
       <LetterDataInfoReq></LetterDataInfoReq>
     {/if}
-    {#if $userData.entry === 'followup'}
-      {#if $userData.step === 'unanswered' || $userData.step === 'print'}
+    {#if $userData.entry === 'followup' && $userData.desire !== 'data_info_request'}
+      {#if $userData.desire === 'unanswered'}
         <LetterDataInfoReqRemind></LetterDataInfoReqRemind>
-      {:else if $userData.desire === 'incomplete_answer' || $userData.step === 'print'}
+      {:else if $userData.desire === 'incomplete_answer'}
         <LetterDataInfoReqDemand></LetterDataInfoReqDemand>
-      {:else if $userData.desire === 'data_correction' || $userData.step === 'print'}
+      {:else if $userData.desire === 'data_correction'}
         <LetterDataInfoReqChange></LetterDataInfoReqChange>
-      {:else if $userData.desire === 'data_deletion' || $userData.step === 'print'}
+      {:else if $userData.desire === 'data_deletion'}
         <LetterDataInfoReqDelete></LetterDataInfoReqDelete>
       {/if}
     {/if}

--- a/src/letter/LetterDataInfoReq.svelte
+++ b/src/letter/LetterDataInfoReq.svelte
@@ -289,8 +289,6 @@
 @media print {
   #letter {
     width: 100% !important;
-    /* A4 */
-    min-height: 297mm;
   }
   p, li {
     break-before: auto;

--- a/src/letter/LetterDataInfoReqChange.svelte
+++ b/src/letter/LetterDataInfoReqChange.svelte
@@ -200,8 +200,6 @@
 @media print {
   #letter {
     width: 100% !important;
-    /* A4 */
-    min-height: 297mm;
   }
 
   p, li {

--- a/src/letter/LetterDataInfoReqDelete.svelte
+++ b/src/letter/LetterDataInfoReqDelete.svelte
@@ -199,8 +199,6 @@
 @media print {
   #letter {
     width: 100% !important;
-    /* A4 */
-    min-height: 297mm;
   }
 
   p, li {

--- a/src/letter/LetterDataInfoReqDemand.svelte
+++ b/src/letter/LetterDataInfoReqDemand.svelte
@@ -201,8 +201,6 @@
 @media print {
   #letter {
     width: 100% !important;
-    /* A4 */
-    min-height: 297mm;
   }
 
   p, li {

--- a/src/letter/LetterDataInfoReqRemind.svelte
+++ b/src/letter/LetterDataInfoReqRemind.svelte
@@ -195,8 +195,6 @@
 @media print {
   #letter {
     width: 100% !important;
-    /* A4 */
-    min-height: 297mm;
   }
 
   p {

--- a/tooling/docker.sh
+++ b/tooling/docker.sh
@@ -2,32 +2,34 @@
 set -euo pipefail
 
 CMD="${1:-}"
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 case "$CMD" in
   dev)
     docker run --rm -it \
       --network host \
-      -v "$(pwd)/../:/app" \
+      -v "${PROJECT_ROOT}:/app" \
       -e VITE_TEST_BANNER=true \
       -w /app \
       node:24-alpine \
       sh -c "npm install && npm run dev"
     ;;
   test)
-    PLAYWRIGHT_VERSION=$(docker run --rm -v "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd):/app" -w /app node:24-alpine \
+    PLAYWRIGHT_VERSION=$(docker run --rm -v "${PROJECT_ROOT}:/app" -w /app node:24-alpine \
       node -e "const p=require('./package.json');console.log(p.devDependencies['@playwright/test'].replace(/[\^~]/,''))")
-    docker run --rm -it \
-      -v "$(pwd)/../:/app" \
+    EXTRA_ARGS="${@:2}"
+    docker run --rm -i \
+      -v "${PROJECT_ROOT}:/app" \
       -w /app \
       --network host \
       "mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble" \
       bash -c "npm install && npm run dev &
                while ! (echo > /dev/tcp/localhost/5173) 2>/dev/null; do sleep 0.5; done
-               npx playwright test -c ./playwright.config.ts"
+               npx playwright test -c ./playwright.config.ts ${EXTRA_ARGS}"
     ;;
   download-data)
     docker run --rm \
-      -v "$(pwd)/../:/app" \
+      -v "${PROJECT_ROOT}:/app" \
       -w /app \
       node:24-alpine \
       sh -c "wget -O public/data_de.json https://github.com/DigitaleGesellschaft/Datenauskunftsbegehren-Data/releases/latest/download/data_de.json && \


### PR DESCRIPTION
This pull request addresses a regression where multiple letters could be rendered simultaneously when printing, and improves test coverage and Docker tooling. The main changes ensure that only one letter is shown in print mode, clean up letter layout CSS, add comprehensive end-to-end tests for printing scenarios, and enhance Docker test script flexibility.

**Bugfixes and Logic Improvements:**

* Updated conditional rendering logic in `App.svelte` to ensure only one letter is displayed in print mode, fixing cases where both the main and follow-up letters could appear at once.

**Testing Enhancements:**

* Added comprehensive Playwright end-to-end tests in `drucken.spec.ts` to verify that only a single letter is rendered in all print scenarios, and that the correct letter content appears depending on user actions.

**Styling and Layout:**

* Removed the fixed `min-height: 297mm` A4 page size from the print CSS in all letter components (`LetterDataInfoReq.svelte`, `LetterDataInfoReqRemind.svelte`, `LetterDataInfoReqDemand.svelte`, `LetterDataInfoReqChange.svelte`, `LetterDataInfoReqDelete.svelte`) to prevent layout issues in print output. [[1]](diffhunk://#diff-6b894561c84e8a4fd93d959c077247449b47addaa68f36eaef0c484a1ef0636eL292-L293) [[2]](diffhunk://#diff-88d4d6b7e6ad34d6459bc9252305f96914b6dbcce70e7d9a5c6ccccd4b2d49b4L198-L199) [[3]](diffhunk://#diff-75998c6b33f0891b60629b063ac253b3cb0d098eda45cd09023222e3ca03c607L204-L205) [[4]](diffhunk://#diff-7b7d3719f96f5d5287d7b8e90ce1f65e4adcfa876e8ca60e672935a405c543a2L203-L204) [[5]](diffhunk://#diff-2cd47a849988728d192d181976accf9ebc71f320d258e6343a4f3cd9b2842588L202-L203)

**Tooling Improvements:**

* Improved `tooling/docker.sh` to use a consistent project root, support extra arguments for Playwright tests, and clean up volume mounting logic for more robust and flexible Docker-based development and testing.