### PR TITLE
feat: show app version and git revision in info screen and test banner

### DIFF
--- a/e2e/base.spec.ts
+++ b/e2e/base.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+import packageJson from '../package.json' with { type: 'json' };
+
+const gitRevision = process.env.GIT_REVISION || execSync('git rev-parse --short HEAD').toString().trim();
 
 test('Seite wird mit dynamisch generiertem Titel angezeigt', async ({ page }) => {
   await page.goto('');
@@ -7,14 +11,14 @@ test('Seite wird mit dynamisch generiertem Titel angezeigt', async ({ page }) =>
   expect(h1Text).toBe('Generiere dein Datenauskunftsbegehren');
 });
 
-test('Info kann angezeigt werden', async ({ page }) => {
+test('Info kann angezeigt werden und zeigt Version und Git-Revision', async ({ page }) => {
   await page.goto('');
 
-  // Info anzeigen (letzter button.circle.one in der Header-Leiste)
   const creditsButton = page.locator('button.circle.one').last();
   await creditsButton.click();
 
-  // Prüfen, dass der entsprechende Text angezeigt wird
-  const textLocator = page.locator('text=Es werden keine Personendaten bei der Verwendung des Generators erhoben: Sämtliche Dateneingaben und Auswahlen verbleiben im Browser der Benutzer:innen.');
-  await expect(textLocator).toBeVisible();
+  const credits = page.locator('.credits');
+  await expect(credits.locator('text=Es werden keine Personendaten bei der Verwendung des Generators erhoben: Sämtliche Dateneingaben und Auswahlen verbleiben im Browser der Benutzer:innen.')).toBeVisible();
+  await expect(credits).toContainText(packageJson.version);
+  await expect(credits).toContainText(gitRevision);
 });

--- a/e2e/drucken-pdf.spec.ts
+++ b/e2e/drucken-pdf.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+const baseState = '"name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"';
+
+test('Kurzer Brief erzeugt beim Drucken eine PDF-Seite', async ({ page }) => {
+  const url = `#{"v":1,"entry":"followup","desire":"unanswered","step":"print",${baseState}}`;
+  await page.goto(url);
+
+  const pdf = await page.pdf({ format: 'A4' });
+  // Count PDF pages: each page dictionary has /Type /Page (singular, not /Pages)
+  const pageCount = (pdf.toString('latin1').match(/\/Type\s*\/Page(?!s)/g) || []).length;
+  expect(pageCount).toBe(1);
+});

--- a/e2e/drucken.spec.ts
+++ b/e2e/drucken.spec.ts
@@ -61,17 +61,6 @@ test('Nachfassen Daten löschen zeigt beim Drucken exakt einen Brief', async ({ 
   await expect(letterSections.first()).toContainText('Aufgrund Ihrer Auskunft ersuche ich Sie, folgende Personendaten zu löschen:');
 });
 
-test('Kurzer Brief erzeugt beim Drucken eine PDF-Seite', async ({ page, browserName }) => {
-  test.skip(browserName !== 'chromium', 'PDF-Generierung nur in Chromium verfügbar');
-
-  const url = `#{"v":1,"entry":"followup","desire":"unanswered","step":"print",${baseState}}`;
-  await page.goto(url);
-
-  const pdf = await page.pdf({ format: 'A4' });
-  // Count PDF pages: each page dictionary has /Type /Page (singular, not /Pages)
-  const pageCount = (pdf.toString('latin1').match(/\/Type\s*\/Page(?!s)/g) || []).length;
-  expect(pageCount).toBe(1);
-});
 
 test('Brief Auskunftsbegehren via Einstiegsmaske zeigt nur einen Brief', async ({ page }) => {
   await page.goto('');

--- a/e2e/test-banner.spec.ts
+++ b/e2e/test-banner.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+import packageJson from '../package.json' with { type: 'json' };
+
+const gitRevision = process.env.GIT_REVISION || execSync('git rev-parse --short HEAD').toString().trim();
+
+test('TestBanner ist sichtbar und zeigt Version und Git-Revision', async ({ page }) => {
+  await page.goto('');
+
+  const banner = page.locator('.test-banner');
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText(packageJson.version);
+  await expect(banner).toContainText(gitRevision);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,9 +4,6 @@ import { defineConfig, devices } from '@playwright/test';
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -42,6 +39,7 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
         locale: 'de-CH',
       },
+      testIgnore: '**/test-banner.spec.ts',
     },
     {
       name: 'firefox',
@@ -50,6 +48,16 @@ export default defineConfig({
         ...devices['Desktop Firefox'],
         locale: 'de-CH',
       },
+      testIgnore: ['**/test-banner.spec.ts', '**/drucken-pdf.spec.ts'],
+    },
+    {
+      name: 'test-banner',
+      use: {
+        baseURL: 'http://localhost:5174',
+        ...devices['Desktop Chrome'],
+        locale: 'de-CH',
+      },
+      testMatch: '**/test-banner.spec.ts',
     },
   ],
 
@@ -59,5 +67,10 @@ export default defineConfig({
   //   url: 'http://localhost:3000',
   //   reuseExistingServer: !process.env.CI,
   // },
+  webServer: {
+    command: 'VITE_TEST_BANNER=true vite --port 5174',
+    url: 'http://localhost:5174',
+    reuseExistingServer: !process.env.CI,
+  },
 });
 

--- a/src/Credits.svelte
+++ b/src/Credits.svelte
@@ -107,7 +107,7 @@
     </li>
   </ul>
   <h2>Code</h2>
-  <p>{$_("version", { default: "Version" })}: {__APP_VERSION__}</p>
+  <p>{$_("version", { default: "Version" })}: {__APP_VERSION__} ({__GIT_REVISION__})</p>
   <p>
     {@html $_(
       "code_license_info",

--- a/src/TestBanner.svelte
+++ b/src/TestBanner.svelte
@@ -3,7 +3,7 @@
 </svelte:head>
 
 <div class="test-banner">
-  Dies ist ein <strong>Testsystem</strong>.
+  Dies ist ein <strong>Testsystem</strong> (v{__APP_VERSION__}, {__GIT_REVISION__}).
   Das produktive System findest du unter
   <a href="https://www.digitale-gesellschaft.ch/auskunftsbegehren" target="_blank" rel="noopener noreferrer">
     digitale-gesellschaft.ch/auskunftsbegehren

--- a/src/TestBanner.svelte
+++ b/src/TestBanner.svelte
@@ -1,10 +1,14 @@
+<script>
+  import { _ } from 'svelte-i18n';
+</script>
+
 <svelte:head>
   <style>:root { --banner-height: 40px; }</style>
 </svelte:head>
 
 <div class="test-banner">
-  Dies ist ein <strong>Testsystem</strong> (v{__APP_VERSION__}, {__GIT_REVISION__}).
-  Das produktive System findest du unter
+  <strong>{$_('test_banner.is_test_system')}</strong> (v{__APP_VERSION__}, {__GIT_REVISION__}).
+  {$_('test_banner.find_production_at')}
   <a href="https://www.digitale-gesellschaft.ch/auskunftsbegehren" target="_blank" rel="noopener noreferrer">
     digitale-gesellschaft.ch/auskunftsbegehren
   </a>

--- a/src/locales/de-CH.json
+++ b/src/locales/de-CH.json
@@ -143,5 +143,9 @@
     "activate_camera_back": "hier Kamera aktivieren um die Rückseite zu fotografieren",
     "hold_id_instructions": "Halt deinen Ausweis vor die Kamera und drücke den Auslöser.",
     "crop_instructions": "Du kannst das Bild danach zuschneiden."
+  },
+  "test_banner": {
+    "is_test_system": "Dies ist ein Testsystem",
+    "find_production_at": "Das produktive System findest du unter"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -143,5 +143,9 @@
     "activate_camera_back": "activate camera here to photograph the back",
     "hold_id_instructions": "Hold your ID in front of the camera and press the shutter.",
     "crop_instructions": "You can crop the image afterwards."
+  },
+  "test_banner": {
+    "is_test_system": "This is a test system",
+    "find_production_at": "The production system is available at"
   }
 }

--- a/src/locales/fr-CH.json
+++ b/src/locales/fr-CH.json
@@ -143,5 +143,9 @@
     "activate_camera_back": "activer la caméra afin de photographier l'arrière",
     "hold_id_instructions": "Tiens le document d'identité devant la caméra - enclenche la.",
     "crop_instructions": "Tu peux ensuite couper l'image."
+  },
+  "test_banner": {
+    "is_test_system": "Ceci est un système de test",
+    "find_production_at": "Le système de production est disponible sur"
   }
 }

--- a/src/locales/it-CH.json
+++ b/src/locales/it-CH.json
@@ -143,5 +143,9 @@
     "activate_camera_back": "attiva qui la fotocamera per fotografare il retro",
     "hold_id_instructions": "Tieni il tuo documento d'identità davanti alla fotocamera e premi il pulsante.",
     "crop_instructions": "Puoi ritagliare l'immagine in seguito."
+  },
+  "test_banner": {
+    "is_test_system": "Questo è un sistema di test",
+    "find_production_at": "Il sistema di produzione è disponibile su"
   }
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,4 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string
+declare const __GIT_REVISION__: string

--- a/tooling/docker.sh
+++ b/tooling/docker.sh
@@ -6,15 +6,18 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 case "$CMD" in
   dev)
+    GIT_REVISION=$(git -C "${PROJECT_ROOT}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
     docker run --rm -it \
       --network host \
       -v "${PROJECT_ROOT}:/app" \
       -e VITE_TEST_BANNER=true \
+      -e GIT_REVISION="${GIT_REVISION}" \
       -w /app \
       node:24-alpine \
       sh -c "npm install && npm run dev"
     ;;
   test)
+    GIT_REVISION=$(git -C "${PROJECT_ROOT}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')
     PLAYWRIGHT_VERSION=$(docker run --rm -v "${PROJECT_ROOT}:/app" -w /app node:24-alpine \
       node -e "const p=require('./package.json');console.log(p.devDependencies['@playwright/test'].replace(/[\^~]/,''))")
     EXTRA_ARGS="${@:2}"
@@ -22,9 +25,12 @@ case "$CMD" in
       -v "${PROJECT_ROOT}:/app" \
       -w /app \
       --network host \
+      -e GIT_REVISION="${GIT_REVISION}" \
       "mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble" \
       bash -c "npm install && npm run dev &
+               VITE_TEST_BANNER=true npx vite --port 5174 &
                while ! (echo > /dev/tcp/localhost/5173) 2>/dev/null; do sleep 0.5; done
+               while ! (echo > /dev/tcp/localhost/5174) 2>/dev/null; do sleep 0.5; done
                npx playwright test -c ./playwright.config.ts ${EXTRA_ARGS}"
     ;;
   download-data)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,22 @@
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { readFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
 
 const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'))
+
+let gitRevision = process.env.GIT_REVISION || 'unknown'
+if (gitRevision === 'unknown') {
+  try {
+    gitRevision = execSync('git rev-parse --short HEAD').toString().trim()
+  } catch { /* not a git repo or git not available */ }
+}
 
 // https://vite.dev/config/
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(version),
+    __GIT_REVISION__: JSON.stringify(gitRevision),
   },
   plugins: [svelte()],
   server: {


### PR DESCRIPTION
This pull request introduces support for displaying the app's Git revision alongside the version in the UI and end-to-end (E2E) tests. It ensures that both the version and the Git commit hash are available during development, testing, and in the browser, and updates the E2E tests and configuration to verify this information is shown correctly. Additionally, it reorganizes E2E tests and Playwright configuration to better handle environment-specific tests.

**Git revision and version display:**

* Adds `__GIT_REVISION__` as a global constant in the Vite build, determined from the environment or via `git rev-parse`, and exposes it alongside `__APP_VERSION__` (`vite.config.ts`, `tooling/docker.sh`) [[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR4-R19) [[2]](diffhunk://#diff-4a902cffa58ec0a39096b580e46caa9d7ac8e9ab5afff3da61eeb3422d09da76R9-R33).
* Updates the `Credits` and `TestBanner` Svelte components to display both the app version and the Git revision (`src/Credits.svelte`, `src/TestBanner.svelte`) [[1]](diffhunk://#diff-c13408d1ead0852692e1f7a7cb435efb03f97acf40d19581115e3fe66e1decddL110-R110) [[2]](diffhunk://#diff-2f5b4513a6da999d52a21c0a1543c083cb1a981e0b4fbcc63e1bff5e1e00a335L6-R6).

**E2E test improvements:**

* Adds new E2E tests to verify that the Git revision and version are shown in the credits and test banner (`e2e/base.spec.ts`, `e2e/test-banner.spec.ts`) [[1]](diffhunk://#diff-667863a3634f63f0a15947cef8e50899c4284b27f3e5eef8f159bd9610e6f686R2-R5) [[2]](diffhunk://#diff-c821a458f5a0b95750a666be1e52805db35a26f6565ce6d5ca3d5c73460ce673R1-R14) [[3]](diffhunk://#diff-667863a3634f63f0a15947cef8e50899c4284b27f3e5eef8f159bd9610e6f686L10-R23).
* Moves the PDF generation test from `e2e/drucken.spec.ts` to a new file `e2e/drucken-pdf.spec.ts` for improved test organization (`e2e/drucken-pdf.spec.ts`, [e2e/drucken.spec.tsL64-L74](diffhunk://#diff-5885c605408769164a9eb64707a3fdc45726bb811eda2f025db8db8b9952d895L64-L74)).

**Playwright configuration updates:**

* Configures Playwright to run the test banner and PDF tests only in Chromium and on a dedicated server with the appropriate environment (`playwright.config.ts`) [[1]](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92R42) [[2]](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92R51-R60) [[3]](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92R70-R74).
* Removes commented-out dotenv import for clarity (`playwright.config.ts`).