### PR TITLE
fix: resolve {causa} placeholder in send_by_post translation

### DIFF
--- a/e2e/drucken.spec.ts
+++ b/e2e/drucken.spec.ts
@@ -73,6 +73,15 @@ test('Kurzer Brief erzeugt beim Drucken eine PDF-Seite', async ({ page, browserN
   expect(pageCount).toBe(1);
 });
 
+test('Print-Seite zeigt aufgelösten causa-Text ohne Platzhalter', async ({ page }) => {
+  const url = `#{"v":1,"langUi":"de","langCor":"de","org":"Migros","entry":"org","types":["payback","online","wlan"],"step":"print",${baseState}}`;
+  await page.goto(url);
+
+  const sendByPostPara = page.locator('.step-print p').first();
+  await expect(sendByPostPara).not.toContainText('{causa}');
+  await expect(sendByPostPara).toContainText('das Datenauskunftsbegehren');
+});
+
 test('Brief Auskunftsbegehren via Einstiegsmaske zeigt nur einen Brief', async ({ page }) => {
   await page.goto('');
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -131,7 +131,7 @@
           <h2>{$_('print.done_title', { default: 'Geschafft' })}</h2>
           <p>{@html $_('print.send_by_post', {
             default: 'Nun musst du {causa} noch <strong>eingeschrieben per Post versenden</strong>.',
-            values: { causa: $_('causa.print.' + normalizedDesire) }
+            values: { causa: $_('causa.print.' + normalizedDesire), strong: (text) => `<strong>${text}</strong>` }
           })}</p>
           <p>{$_('print.deadline_info', { default: 'Ab dem Eingang bleiben 30 Tage für die Beantwortung. Speichere einen Termin im Kalender, um dich für ein allfälliges Nachfragen erinnern zu lassen, falls du bis dahin keine Antwort erhalten hast.' })}</p>
           <IcsDownload></IcsDownload>


### PR DESCRIPTION
With `ignoreTag: false` in svelte-i18n, IntlMessageFormat parses `<strong>` as a rich text element and requires a handler function in `values`. Without it, format() throws an error that svelte-i18n catches silently, returning the raw message string with {causa} unresolved. Add a `strong` handler to fix the interpolation.

closes #41 