### PR TITLE
test: add visual screenshots to all e2e tests and upload as CI artifact

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,3 +63,11 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+      - name: Upload Screenshots
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: screenshots
+          path: screenshots/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/screenshots/
 
 dist
 

--- a/e2e/base.spec.ts
+++ b/e2e/base.spec.ts
@@ -28,7 +28,8 @@ test('Info kann angezeigt werden', async ({ page }, testInfo) => {
   await expect(textLocator).toBeVisible();
 
   await page.screenshot({ path: screenshotPath(testInfo, '02-info-overlay.png'), fullPage: true });
-  
+  });
+
 test('Info kann angezeigt werden und zeigt Version und Git-Revision', async ({ page }) => {
   await page.goto('');
 

--- a/e2e/base.spec.ts
+++ b/e2e/base.spec.ts
@@ -1,14 +1,19 @@
 import { test, expect } from '@playwright/test';
+import { screenshotPath } from './screenshot';
 
-test('Seite wird mit dynamisch generiertem Titel angezeigt', async ({ page }) => {
+test('Seite wird mit dynamisch generiertem Titel angezeigt', async ({ page }, testInfo) => {
   await page.goto('');
 
   const h1Text = await page.locator('h1').textContent();
   expect(h1Text).toBe('Generiere dein Datenauskunftsbegehren');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-startseite.png'), fullPage: true });
 });
 
-test('Info kann angezeigt werden', async ({ page }) => {
+test('Info kann angezeigt werden', async ({ page }, testInfo) => {
   await page.goto('');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-startseite.png'), fullPage: true });
 
   // Info anzeigen (letzter button.circle.one in der Header-Leiste)
   const creditsButton = page.locator('button.circle.one').last();
@@ -17,4 +22,6 @@ test('Info kann angezeigt werden', async ({ page }) => {
   // Prüfen, dass der entsprechende Text angezeigt wird
   const textLocator = page.locator('text=Es werden keine Personendaten bei der Verwendung des Generators erhoben: Sämtliche Dateneingaben und Auswahlen verbleiben im Browser der Benutzer:innen.');
   await expect(textLocator).toBeVisible();
+
+  await page.screenshot({ path: screenshotPath(testInfo, '02-info-overlay.png'), fullPage: true });
 });

--- a/e2e/date.spec.ts
+++ b/e2e/date.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { screenshotPath } from './screenshot';
 
 /**
  * Mirrors the deadline calculation in IcsDownload.svelte:
@@ -28,7 +29,7 @@ const PRINT_URL = '#{"v":1,"step":"print","name":"E2E Person","date":"28.7.2025"
 const EVENT_CALL_URL = '#{"v":1,"entry":"event","events":["call"],"event":"call"}';
 
 test.describe('IcsDownload', () => {
-  test('ICS Formular wird auf dem Druckblatt angezeigt', async ({ page }) => {
+  test('ICS Formular wird auf dem Druckblatt angezeigt', async ({ page }, testInfo) => {
     await page.goto(PRINT_URL);
 
     const form = page.locator('form.ics-download');
@@ -36,6 +37,8 @@ test.describe('IcsDownload', () => {
     await expect(form.locator('input[type="date"]')).toBeVisible();
     await expect(form.locator('input[type="time"]')).toBeVisible();
     await expect(form.locator('button')).toBeVisible();
+
+    await page.screenshot({ path: screenshotPath(testInfo, '01-ics-formular.png'), fullPage: true });
   });
 
   test('ICS Datum ist 40 Tage (plus Wochenend-Puffer) in der Zukunft', async ({ page }) => {
@@ -68,15 +71,17 @@ test.describe('IcsDownload', () => {
 });
 
 test.describe('VariableInput Datum', () => {
-  test('Datumseingabe erscheint für Ereignis «Werbeanruf»', async ({ page }) => {
+  test('Datumseingabe erscheint für Ereignis «Werbeanruf»', async ({ page }, testInfo) => {
     await page.goto(EVENT_CALL_URL);
 
     const dateLabel = page.locator('label', { hasText: 'Wann' });
     await expect(dateLabel).toBeVisible();
     await expect(page.locator('input[type="date"]')).toBeVisible();
+
+    await page.screenshot({ path: screenshotPath(testInfo, '01-datumseingabe-werbeanruf.png'), fullPage: true });
   });
 
-  test('Datumseingabe konvertiert yyyy-MM-dd in dd.MM.yyyy für den Brief', async ({ page }) => {
+  test('Datumseingabe konvertiert yyyy-MM-dd in dd.MM.yyyy für den Brief', async ({ page }, testInfo) => {
     await page.goto(EVENT_CALL_URL);
 
     const dateInput = page.locator('input[type="date"]');
@@ -87,11 +92,15 @@ test.describe('VariableInput Datum', () => {
     await generateButton.click();
 
     await expect(page.locator('section#letter')).toContainText('15.06.2099');
+
+    await page.screenshot({ path: screenshotPath(testInfo, '01-datum-konvertiert-brief.png'), fullPage: true });
   });
 
-  test('Vorausgefülltes Datum (dd.MM.yyyy) wird als yyyy-MM-dd im Eingabefeld angezeigt', async ({ page }) => {
+  test('Vorausgefülltes Datum (dd.MM.yyyy) wird als yyyy-MM-dd im Eingabefeld angezeigt', async ({ page }, testInfo) => {
     await page.goto('#{"v":1,"entry":"event","events":["call"],"event":"call","eventDate":"15.06.2099"}');
 
     await expect(page.locator('input[type="date"]')).toHaveValue('2099-06-15');
+
+    await page.screenshot({ path: screenshotPath(testInfo, '01-vorausgefuelltes-datum.png'), fullPage: true });
   });
 });

--- a/e2e/datenauskunftsbegehren.spec.ts
+++ b/e2e/datenauskunftsbegehren.spec.ts
@@ -1,33 +1,38 @@
 import { test, expect } from '@playwright/test';
+import { screenshotPath } from './screenshot';
 
-test('Der generierte Brief enthält die Daten aus der Url', async ({ page }) => {
+test('Der generierte Brief enthält die Daten aus der Url', async ({ page }, testInfo) => {
   const url = '#{"v":1,"step":"data_info_request","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
   await page.goto(url);
 
   const letterSection = await page.locator('section#letter');
 
   const sectionText = await letterSection.textContent();
-  
+
   // Prüfen, dass die Daten aus der URL im Brief zu finden sind
   expect(sectionText).toContain('E2E Person');
   expect(sectionText).toContain('E2E Absender');
   expect(sectionText).toContain('E2E Empfänger');
   expect(sectionText).toContain('28.7.2025');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-aus-url.png'), fullPage: true });
 });
 
-test('Datenauskunftsbegehren für Swisscom generieren', async ({ page }) => {
+test('Datenauskunftsbegehren für Swisscom generieren', async ({ page }, testInfo) => {
   await page.goto('');
 
   // Organisationsauswahl öffnen, prüfen, dass diese gut belegt ist und Swisscom auswählen
   const searchInput = page.locator('input[placeholder="Suche ..."]');
-  
+
   await searchInput.click();
 
-  const listContainer = page.locator('div.svelte-select-list');;
+  const listContainer = page.locator('div.svelte-select-list');
   await expect(listContainer).toContainText('Agrisano');
   await expect(listContainer).toContainText('Coop Rechtsschutz');
   await expect(listContainer).toContainText('Mercedes');
   await expect(listContainer).toContainText('Swiss Life');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-dropdown-offen.png') });
 
   await searchInput.fill('Swisscom');
   const swisscomOption = listContainer.locator('div.item >> nth=2');
@@ -44,6 +49,8 @@ test('Datenauskunftsbegehren für Swisscom generieren', async ({ page }) => {
   const wlanCheckbox = stepUI.locator('input[type="checkbox"][value="wlan"]');
   await expect(wlanCheckbox).toBeChecked();
 
+  await page.screenshot({ path: screenshotPath(testInfo, '02-swisscom-formular.png'), fullPage: true });
+
   // E-Mail Feld ist da und verschwindet nachdem Online-Portal abgewählt wird
   const emailField = stepUI.locator('input[type="email"]');
   await expect(emailField).toBeVisible();
@@ -58,6 +65,8 @@ test('Datenauskunftsbegehren für Swisscom generieren', async ({ page }) => {
   const userAddressField = stepUI.locator('textarea#userAddress');
   await userAddressField.fill('E2E Strasse\n1000 E2EOrt');
 
+  await page.screenshot({ path: screenshotPath(testInfo, '03-formular-ausgefuellt.png'), fullPage: true });
+
   // Brief erstellen und Inhalt prüfen
   const generateButton = page.locator('button', { hasText: 'Brief generieren' });
   await generateButton.click();
@@ -69,4 +78,6 @@ test('Datenauskunftsbegehren für Swisscom generieren', async ({ page }) => {
   await expect(letterSection).toContainText('Mobilfunk');
   await expect(letterSection).toContainText('WLAN');
   await expect(letterSection).not.toContainText('Online-Portal');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '04-brief-generiert.png'), fullPage: true });
 });

--- a/e2e/drucken.spec.ts
+++ b/e2e/drucken.spec.ts
@@ -1,11 +1,12 @@
 import { test, expect } from '@playwright/test';
+import { screenshotPath } from './screenshot';
 
 const baseState = '"name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"';
 
 // Regression: "Brief Auskunftsbegehren" via StepOne desires section set entry='followup' +
 // desire='data_info_request', causing both the main letter and a followup letter to render
 // simultaneously when printing.
-test('Brief Auskunftsbegehren zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+test('Brief Auskunftsbegehren zeigt beim Drucken exakt einen Brief', async ({ page }, testInfo) => {
   const url = `#{"v":1,"entry":"followup","desire":"data_info_request","step":"print",${baseState}}`;
   await page.goto(url);
 
@@ -13,25 +14,31 @@ test('Brief Auskunftsbegehren zeigt beim Drucken exakt einen Brief', async ({ pa
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).toContainText('Datenauskunftsbegehren');
   await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-druckansicht-auskunftsbegehren.png'), fullPage: true });
 });
 
-test('Normaler Brief zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+test('Normaler Brief zeigt beim Drucken exakt einen Brief', async ({ page }, testInfo) => {
   const url = `#{"v":1,"step":"print",${baseState}}`;
   await page.goto(url);
 
   await expect(page.locator('section[id="letter"]')).toHaveCount(1);
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-druckansicht-normal.png'), fullPage: true });
 });
 
-test('Nachfassen ausbleibende Auskunft zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+test('Nachfassen ausbleibende Auskunft zeigt beim Drucken exakt einen Brief', async ({ page }, testInfo) => {
   const url = `#{"v":1,"entry":"followup","desire":"unanswered","step":"print",${baseState}}`;
   await page.goto(url);
 
   const letterSections = page.locator('section[id="letter"]');
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).toContainText('Ausbleibende Auskunft');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-druckansicht-ausbleibende-auskunft.png'), fullPage: true });
 });
 
-test('Nachfassen unvollständige Antwort zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+test('Nachfassen unvollständige Antwort zeigt beim Drucken exakt einen Brief', async ({ page }, testInfo) => {
   const url = `#{"v":1,"entry":"followup","desire":"incomplete_answer","step":"print",${baseState}}`;
   await page.goto(url);
 
@@ -39,9 +46,11 @@ test('Nachfassen unvollständige Antwort zeigt beim Drucken exakt einen Brief', 
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
   await expect(letterSections.first()).toContainText('Ich gehe davon aus, dass insbesondere folgende Informationen fehlen');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-druckansicht-unvollstaendige-antwort.png'), fullPage: true });
 });
 
-test('Nachfassen Daten korrigieren zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+test('Nachfassen Daten korrigieren zeigt beim Drucken exakt einen Brief', async ({ page }, testInfo) => {
   const url = `#{"v":1,"entry":"followup","desire":"data_correction","step":"print",${baseState}}`;
   await page.goto(url);
 
@@ -49,9 +58,11 @@ test('Nachfassen Daten korrigieren zeigt beim Drucken exakt einen Brief', async 
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
   await expect(letterSections.first()).toContainText('Aufgrund Ihrer Auskunft stellte ich fest, dass von Ihnen bearbeitete Personendaten unrichtig sind.');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-druckansicht-daten-korrigieren.png'), fullPage: true });
 });
 
-test('Nachfassen Daten löschen zeigt beim Drucken exakt einen Brief', async ({ page }) => {
+test('Nachfassen Daten löschen zeigt beim Drucken exakt einen Brief', async ({ page }, testInfo) => {
   const url = `#{"v":1,"entry":"followup","desire":"data_deletion","step":"print",${baseState}}`;
   await page.goto(url);
 
@@ -59,6 +70,8 @@ test('Nachfassen Daten löschen zeigt beim Drucken exakt einen Brief', async ({ 
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
   await expect(letterSections.first()).toContainText('Aufgrund Ihrer Auskunft ersuche ich Sie, folgende Personendaten zu löschen:');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-druckansicht-daten-loeschen.png'), fullPage: true });
 });
 
 test('Kurzer Brief erzeugt beim Drucken eine PDF-Seite', async ({ page, browserName }) => {
@@ -73,12 +86,14 @@ test('Kurzer Brief erzeugt beim Drucken eine PDF-Seite', async ({ page, browserN
   expect(pageCount).toBe(1);
 });
 
-test('Brief Auskunftsbegehren via Einstiegsmaske zeigt nur einen Brief', async ({ page }) => {
+test('Brief Auskunftsbegehren via Einstiegsmaske zeigt nur einen Brief', async ({ page }, testInfo) => {
   await page.goto('');
 
   // "Brief Auskunftsbegehren" aus der Desires-Liste in StepOne auswählen
   const briefButton = page.locator('button', { hasText: 'Brief Auskunftsbegehren' });
   await briefButton.click();
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-nachfassen-formular.png'), fullPage: true });
 
   // Adressfelder ausfüllen (StepFollowUp)
   const userNameField = page.locator('input#userName');
@@ -97,4 +112,6 @@ test('Brief Auskunftsbegehren via Einstiegsmaske zeigt nur einen Brief', async (
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).toContainText('Datenauskunftsbegehren');
   await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '02-brief-auskunftsbegehren.png'), fullPage: true });
 });

--- a/e2e/ereignis.spec.ts
+++ b/e2e/ereignis.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { screenshotPath } from './screenshot';
 
 async function fillUserAddress(page: Page, name: string, address: string) {
   await page.locator('input#userName').fill(name);
@@ -16,11 +17,14 @@ async function generateLetter(page: Page) {
   await expect(page.locator('section#letter')).toBeVisible();
 }
 
-test('Ereignis Werbeanruf: Brief enthält Datum und Telefonnummer', async ({ page }) => {
+test('Ereignis Werbeanruf: Brief enthält Datum und Telefonnummer', async ({ page }, testInfo) => {
   await selectEvent(page, 'Ich habe einen Werbeanruf erhalten');
   await page.getByLabel('Wann').fill('2024-03-15');
   await page.getByLabel('Telefon-Nr.').fill('+41 44 123 45 67');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-werbeanruf-formular.png'), fullPage: true });
+
   await generateLetter(page);
 
   const letter = page.locator('section#letter');
@@ -28,13 +32,18 @@ test('Ereignis Werbeanruf: Brief enthält Datum und Telefonnummer', async ({ pag
   await expect(letter).toContainText('15.03.2024');
   await expect(letter).toContainText('+41 44 123 45 67');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '02-werbeanruf-brief.png'), fullPage: true });
 });
 
-test('Ereignis Werbemail: Brief enthält Datum und E-Mail-Adresse', async ({ page }) => {
+test('Ereignis Werbemail: Brief enthält Datum und E-Mail-Adresse', async ({ page }, testInfo) => {
   await selectEvent(page, 'Ich habe ein Werbemail erhalten');
   await page.getByLabel('Wann').fill('2024-06-20');
   await page.getByLabel('E-Mail-Adresse').fill('test@example.com');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-werbemail-formular.png'), fullPage: true });
+
   await generateLetter(page);
 
   const letter = page.locator('section#letter');
@@ -42,27 +51,39 @@ test('Ereignis Werbemail: Brief enthält Datum und E-Mail-Adresse', async ({ pag
   await expect(letter).toContainText('20.06.2024');
   await expect(letter).toContainText('test@example.com');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '02-werbemail-brief.png'), fullPage: true });
 });
 
-test('Ereignis Werbung per Post: Brief enthält Datum', async ({ page }) => {
+test('Ereignis Werbung per Post: Brief enthält Datum', async ({ page }, testInfo) => {
   await selectEvent(page, 'Mir wurde Werbung per Post zugestellt');
   await page.getByLabel('Wann').fill('2024-09-10');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-werbung-post-formular.png'), fullPage: true });
+
   await generateLetter(page);
 
   const letter = page.locator('section#letter');
   await expect(letter).toContainText('Werbung per Post');
   await expect(letter).toContainText('10.09.2024');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '02-werbung-post-brief.png'), fullPage: true });
 });
 
-test('Ereignis Gerücht: Brief enthält den spezifischen Absatz', async ({ page }) => {
+test('Ereignis Gerücht: Brief enthält den spezifischen Absatz', async ({ page }, testInfo) => {
   await selectEvent(page, 'Ich habe vernommen, dass ...');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-geruecht-formular.png'), fullPage: true });
+
   await generateLetter(page);
 
   const letter = page.locator('section#letter');
   await expect(letter).toContainText('Im Zusammenhang mit');
   await expect(letter).toContainText('werden Personendaten bearbeitet');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '02-geruecht-brief.png'), fullPage: true });
 });

--- a/e2e/geschaeftsbereich.spec.ts
+++ b/e2e/geschaeftsbereich.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { screenshotPath } from './screenshot';
 
 async function fillUserAddress(page: Page, name: string, address: string) {
   await page.locator('input#userName').fill(name);
@@ -16,7 +17,7 @@ async function generateLetter(page: Page) {
   await expect(page.locator('section#letter')).toBeVisible();
 }
 
-test('Geschäftsbereich Adresshandel: Brief enthält spezifischen Absatz', async ({ page }) => {
+test('Geschäftsbereich Adresshandel: Brief enthält spezifischen Absatz', async ({ page }, testInfo) => {
   await selectType(page, 'Adresshandel');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
@@ -25,9 +26,11 @@ test('Geschäftsbereich Adresshandel: Brief enthält spezifischen Absatz', async
   await expect(letter).toContainText('Adresshandel');
   await expect(letter).toContainText('Zielgruppen');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-adresshandel.png'), fullPage: true });
 });
 
-test('Geschäftsbereich Kreditauskunft: Brief enthält spezifischen Absatz', async ({ page }) => {
+test('Geschäftsbereich Kreditauskunft: Brief enthält spezifischen Absatz', async ({ page }, testInfo) => {
   await selectType(page, 'Kreditauskunft');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
@@ -36,9 +39,11 @@ test('Geschäftsbereich Kreditauskunft: Brief enthält spezifischen Absatz', asy
   await expect(letter).toContainText('Kreditauskunft');
   await expect(letter).toContainText('Bonitätsprüfung');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-kreditauskunft.png'), fullPage: true });
 });
 
-test('Geschäftsbereich Gastrodaten: Brief enthält spezifischen Absatz', async ({ page }) => {
+test('Geschäftsbereich Gastrodaten: Brief enthält spezifischen Absatz', async ({ page }, testInfo) => {
   await selectType(page, 'Gastrodaten');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
@@ -47,9 +52,11 @@ test('Geschäftsbereich Gastrodaten: Brief enthält spezifischen Absatz', async 
   await expect(letter).toContainText('Gastronomie');
   await expect(letter).toContainText('Contact Tracing');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-gastrodaten.png'), fullPage: true });
 });
 
-test('Geschäftsbereich Kundenkarten-Anbieter: Brief enthält spezifischen Absatz', async ({ page }) => {
+test('Geschäftsbereich Kundenkarten-Anbieter: Brief enthält spezifischen Absatz', async ({ page }, testInfo) => {
   await selectType(page, 'Kundenkarten-Anbieter');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
@@ -57,9 +64,11 @@ test('Geschäftsbereich Kundenkarten-Anbieter: Brief enthält spezifischen Absat
   const letter = page.locator('section#letter');
   await expect(letter).toContainText('Kundenkarte');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-kundenkarte.png'), fullPage: true });
 });
 
-test('Geschäftsbereich Mobilfunkprovider: Brief enthält BÜPF-Absatz und Handy-Nummer', async ({ page }) => {
+test('Geschäftsbereich Mobilfunkprovider: Brief enthält BÜPF-Absatz und Handy-Nummer', async ({ page }, testInfo) => {
   await selectType(page, 'Mobilfunkprovider');
   await page.getByLabel('Handy-Nummer').fill('+41 79 123 45 67');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
@@ -71,9 +80,11 @@ test('Geschäftsbereich Mobilfunkprovider: Brief enthält BÜPF-Absatz und Handy
   await expect(letter).toContainText('+41 79 123 45 67');
   await expect(letter).toContainText('Art. 45 FMG');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-mobilfunk.png'), fullPage: true });
 });
 
-test('Geschäftsbereich Mobilität: Brief enthält Fahrzeug-Absatz und Fahrzeuginformationen', async ({ page }) => {
+test('Geschäftsbereich Mobilität: Brief enthält Fahrzeug-Absatz und Fahrzeuginformationen', async ({ page }, testInfo) => {
   await selectType(page, 'Mobilität');
   await page.getByLabel('Infos zum Fahrzeug').fill('VW Golf, ZH 123 456');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
@@ -84,9 +95,11 @@ test('Geschäftsbereich Mobilität: Brief enthält Fahrzeug-Absatz und Fahrzeugi
   await expect(letter).toContainText('Fahrzeug');
   await expect(letter).toContainText('VW Golf, ZH 123 456');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-mobilitaet.png'), fullPage: true });
 });
 
-test('Geschäftsbereich Online-Portal: Brief enthält E-Mail-Adresse', async ({ page }) => {
+test('Geschäftsbereich Online-Portal: Brief enthält E-Mail-Adresse', async ({ page }, testInfo) => {
   await selectType(page, 'Online-Portal');
   await page.getByLabel('E-Mail-Adresse').fill('test@example.com');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
@@ -97,9 +110,11 @@ test('Geschäftsbereich Online-Portal: Brief enthält E-Mail-Adresse', async ({ 
   await expect(letter).toContainText('Kundenaktivität');
   await expect(letter).toContainText('test@example.com');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-online-portal.png'), fullPage: true });
 });
 
-test('Geschäftsbereich Parkplatz-Anbieter: Brief enthält spezifischen Absatz', async ({ page }) => {
+test('Geschäftsbereich Parkplatz-Anbieter: Brief enthält spezifischen Absatz', async ({ page }, testInfo) => {
   await selectType(page, 'Parkplatz-Anbieter');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
@@ -108,9 +123,11 @@ test('Geschäftsbereich Parkplatz-Anbieter: Brief enthält spezifischen Absatz',
   await expect(letter).toContainText('parkingprovider');
   await expect(letter).toContainText('Parkieren');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-parkplatz.png'), fullPage: true });
 });
 
-test('Geschäftsbereich WLAN-Anbieter: Brief enthält BÜPF-Absatz und Handy-Nummer', async ({ page }) => {
+test('Geschäftsbereich WLAN-Anbieter: Brief enthält BÜPF-Absatz und Handy-Nummer', async ({ page }, testInfo) => {
   await selectType(page, 'WLAN-Anbieter');
   await page.getByLabel('Handy-Nummer').fill('+41 79 987 65 43');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
@@ -122,4 +139,6 @@ test('Geschäftsbereich WLAN-Anbieter: Brief enthält BÜPF-Absatz und Handy-Num
   await expect(letter).toContainText('+41 79 987 65 43');
   await expect(letter).toContainText('Art. 45 FMG');
   await expect(letter).toContainText('E2E Person');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-wlan.png'), fullPage: true });
 });

--- a/e2e/language.spec.ts
+++ b/e2e/language.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { screenshotPath } from './screenshot';
 
 const languages = [
   {
@@ -35,18 +36,22 @@ const languages = [
   },
 ];
 
-test('Standardsprache ist Deutsch', async ({ page }) => {
+test('Standardsprache ist Deutsch', async ({ page }, testInfo) => {
   await page.goto('');
   await expect(page.locator('h1')).toHaveText('Generiere dein Datenauskunftsbegehren');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-startseite-deutsch.png'), fullPage: true });
 });
 
 for (const lang of languages) {
-  test(`UI-Sprache auf ${lang.label} umstellen`, async ({ page }) => {
+  test(`UI-Sprache auf ${lang.label} umstellen`, async ({ page }, testInfo) => {
     await page.goto('');
 
     // Spracheinstellungen öffnen (erster button.circle.one)
     const settingsButton = page.locator('button.circle.one').first();
     await settingsButton.click();
+
+    await page.screenshot({ path: screenshotPath(testInfo, '01-spracheinstellungen.png'), fullPage: true });
 
     // Sprache auswählen
     await page.locator(`input[name="ui-language"][value="${lang.code}"]`).click();
@@ -58,6 +63,8 @@ for (const lang of languages) {
     // Spracheinstellungen-Dialog prüfen
     await expect(page.locator('.language-picker h2')).toHaveText(lang.languagePickerTitle);
     await expect(page.locator('.language-picker fieldset').first().locator('legend')).toHaveText(lang.uiLanguageLabel);
+
+    await page.screenshot({ path: screenshotPath(testInfo, `02-sprache-${lang.code}.png`), fullPage: true });
   });
 }
 
@@ -76,7 +83,7 @@ function letterHash(langUi: string, langCor: string): string {
   return encodeURI(JSON.stringify({ step: 'data_info_request', langUi, langCor, v: 1 }));
 }
 
-test('UI Deutsch, Korrespondenzsprache Französisch: Seite auf Deutsch, Brief auf Französisch', async ({ page }) => {
+test('UI Deutsch, Korrespondenzsprache Französisch: Seite auf Deutsch, Brief auf Französisch', async ({ page }, testInfo) => {
   await page.goto(`#${letterHash('de', 'fr')}`);
 
   // UI ist Deutsch — geprüft an der "zurück"-Schaltfläche, da der App-Titel auf der Briefseite nicht gerendert wird
@@ -85,9 +92,11 @@ test('UI Deutsch, Korrespondenzsprache Französisch: Seite auf Deutsch, Brief au
   // Briefinhalt ist Französisch
   await expect(page.locator('#letter .salutation')).toContainText(letterSnippets.fr.salutation);
   await expect(page.locator('#letter .address-to')).toContainText(letterSnippets.fr.registeredMail);
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-ui-de-brief-fr.png'), fullPage: true });
 });
 
-test('UI Französisch, Korrespondenzsprache Deutsch: Seite auf Französisch, Brief auf Deutsch', async ({ page }) => {
+test('UI Französisch, Korrespondenzsprache Deutsch: Seite auf Französisch, Brief auf Deutsch', async ({ page }, testInfo) => {
   await page.goto(`#${letterHash('fr', 'de')}`);
 
   // UI ist Französisch — geprüft an der "zurück"-Schaltfläche
@@ -96,9 +105,11 @@ test('UI Französisch, Korrespondenzsprache Deutsch: Seite auf Französisch, Bri
   // Briefinhalt ist Deutsch
   await expect(page.locator('#letter .salutation')).toContainText(letterSnippets.de.salutation);
   await expect(page.locator('#letter .address-to')).toContainText(letterSnippets.de.registeredMail);
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-ui-fr-brief-de.png'), fullPage: true });
 });
 
-test('UI-Sprache von Deutsch auf Englisch wechseln', async ({ page }) => {
+test('UI-Sprache von Deutsch auf Englisch wechseln', async ({ page }, testInfo) => {
   await page.goto('');
 
   // Seite ist zuerst auf Deutsch
@@ -110,15 +121,19 @@ test('UI-Sprache von Deutsch auf Englisch wechseln', async ({ page }) => {
 
   // Seite ist jetzt auf Englisch
   await expect(page.locator('h1')).toHaveText('Generate your data access request');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-sprache-gewechselt-englisch.png'), fullPage: true });
 });
 
-test('Sprachen bleiben nach "Eingaben zurücksetzen" erhalten', async ({ page }) => {
+test('Sprachen bleiben nach "Eingaben zurücksetzen" erhalten', async ({ page }, testInfo) => {
   await page.goto('');
 
   // UI-Sprache auf Englisch, Korrespondenzsprache auf Französisch setzen
   await page.locator('button.circle.one').first().click();
   await page.locator('input[name="ui-language"][value="en"]').click();
   await page.locator('input[name="correspondence-language"][value="fr"]').click();
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-spracheinstellungen.png'), fullPage: true });
 
   // Spracheinstellungen schliessen (Close-Button im Overlay)
   await page.locator('.overlay header button').click();
@@ -140,4 +155,6 @@ test('Sprachen bleiben nach "Eingaben zurücksetzen" erhalten', async ({ page })
   await page.locator('button.circle.one').first().click();
   await expect(page.locator('input[name="correspondence-language"][value="fr"]')).toBeChecked();
   await expect(page.locator('input[name="ui-language"][value="en"]')).toBeChecked();
+
+  await page.screenshot({ path: screenshotPath(testInfo, '02-sprachen-nach-reset.png'), fullPage: true });
 });

--- a/e2e/nachfassen.spec.ts
+++ b/e2e/nachfassen.spec.ts
@@ -1,12 +1,19 @@
 import { test, expect } from '@playwright/test';
+import { screenshotPath } from './screenshot';
 
-test('Nachfassen bei ausbleibender Antwort', async ({ page }) => {
-  const url = '#{"v":1,"step":"data_info_request","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
-  await page.goto(url);
+const baseUrl = '#{"v":1,"step":"data_info_request","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
+
+test('Nachfassen bei ausbleibender Antwort', async ({ page }, testInfo) => {
+  await page.goto(baseUrl);
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-ansicht.png'), fullPage: true });
 
   // Nachfassen und erhielt keine Antwort auswählen
   const nachfassenButton = page.locator('button', { hasText: 'Nachfassen' });
   await nachfassenButton.click();
+
+  await page.screenshot({ path: screenshotPath(testInfo, '02-nachfassen-auswahl.png'), fullPage: true });
+
   const keineAntwortButton = page.locator('button', { hasText: 'Ich erhielt keine Antwort' });
   await keineAntwortButton.click();
 
@@ -18,11 +25,12 @@ test('Nachfassen bei ausbleibender Antwort', async ({ page }) => {
   expect(sectionText).toContain('E2E Absender');
   expect(sectionText).toContain('E2E Empfänger');
   expect(sectionText).toContain('28.7.2025');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '03-brief-ausbleibende-auskunft.png'), fullPage: true });
 });
 
-test('Nachfassen unvollständige Antwort', async ({ page }) => {
-  const url = '#{"v":1,"step":"data_info_request","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
-  await page.goto(url);
+test('Nachfassen unvollständige Antwort', async ({ page }, testInfo) => {
+  await page.goto(baseUrl);
 
   // Nachfassen und unvollständige Antwort auswählen
   const nachfassenButton = page.locator('button', { hasText: 'Nachfassen' });
@@ -38,11 +46,12 @@ test('Nachfassen unvollständige Antwort', async ({ page }) => {
   expect(sectionText).toContain('E2E Absender');
   expect(sectionText).toContain('E2E Empfänger');
   expect(sectionText).toContain('28.7.2025');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-unvollstaendige-antwort.png'), fullPage: true });
 });
 
-test('Nachfassen Daten korrigieren lassen', async ({ page }) => {
-  const url = '#{"v":1,"step":"data_info_request","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
-  await page.goto(url);
+test('Nachfassen Daten korrigieren lassen', async ({ page }, testInfo) => {
+  await page.goto(baseUrl);
 
   // Nachfassen und Daten korrigieren auswählen
   const nachfassenButton = page.locator('button', { hasText: 'Nachfassen' });
@@ -58,13 +67,14 @@ test('Nachfassen Daten korrigieren lassen', async ({ page }) => {
   expect(sectionText).toContain('E2E Absender');
   expect(sectionText).toContain('E2E Empfänger');
   expect(sectionText).toContain('28.7.2025');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-daten-korrigieren.png'), fullPage: true });
 });
 
-test('Nachfassen Daten löschen lassen', async ({ page }) => {
-  const url = '#{"v":1,"step":"data_info_request","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
-  await page.goto(url);
+test('Nachfassen Daten löschen lassen', async ({ page }, testInfo) => {
+  await page.goto(baseUrl);
 
-  // Nchfassen und Daten löschen
+  // Nachfassen und Daten löschen
   const nachfassenButton = page.locator('button', { hasText: 'Nachfassen' });
   await nachfassenButton.click();
   const keineAntwortButton = page.locator('button', { hasText: 'Ich möchte Daten löschen lassen' });
@@ -78,4 +88,6 @@ test('Nachfassen Daten löschen lassen', async ({ page }) => {
   expect(sectionText).toContain('E2E Absender');
   expect(sectionText).toContain('E2E Empfänger');
   expect(sectionText).toContain('28.7.2025');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-daten-loeschen.png'), fullPage: true });
 });

--- a/e2e/screenshot.ts
+++ b/e2e/screenshot.ts
@@ -1,0 +1,10 @@
+import type { TestInfo } from '@playwright/test';
+import path from 'path';
+
+export function screenshotPath(testInfo: TestInfo, name: string): string {
+  const safeTitle = testInfo.title
+    .replace(/[^\w]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 60);
+  return path.join('screenshots', testInfo.project.name, `${safeTitle}--${name}.png`);
+}


### PR DESCRIPTION
Add `page.screenshot()` calls at key UI states in all Playwright specs (form open, letter generated, print view, overlays, language switch). Screenshots are written to a shared `screenshots/<browser>/` directory via a `screenshotPath()` helper in `e2e/screenshot.ts`. The GitHub Actions workflow uploads the directory as a `screenshots` artifact with 30-day retention alongside the existing Playwright report.