### PR TITLE
fix(step-event): show event label in details header instead of undefined

### DIFF
--- a/e2e/ereignis.spec.ts
+++ b/e2e/ereignis.spec.ts
@@ -57,6 +57,7 @@ test('Ereignis Werbemail: Brief enthält Datum und E-Mail-Adresse', async ({ pag
 
 test('Ereignis Werbung per Post: Brief enthält Datum', async ({ page }, testInfo) => {
   await selectEvent(page, 'Mir wurde Werbung per Post zugestellt');
+  await expect(page.locator('h2')).toContainText('Mir wurde Werbung per Post zugestellt');
   await page.getByLabel('Wann').fill('2024-09-10');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
 

--- a/src/entry/StepEvent.svelte
+++ b/src/entry/StepEvent.svelte
@@ -10,7 +10,7 @@
   let variables = $derived(selectedEvent ? selectedEvent.variables : [])
 </script>
 {#if selectedEvent}
-  <h2>{$_("step_event.details_header", { default: "Mach noch einige Angaben für das Auskunftsbegehren aus speziellem Grund «{eventName}»", values: { eventName: selectedEvent.name } })}</h2>
+  <h2>{$_("step_event.details_header", { default: "Mach noch einige Angaben für das Auskunftsbegehren aus speziellem Grund «{eventName}»", values: { eventName: selectedEvent.label } })}</h2>
   <div class="data-entry-form">
     {#if selectedEvent.handle !== 'rumor' && variables.length > 0}
     <section>


### PR DESCRIPTION
Use `selectedEvent.label` instead of `selectedEvent.name` in StepEvent.svelte, since the Event model only exposes a `label` property. The missing `name` property caused the heading to render with an empty event name.