### PR TITLE
fix: show Nachfassen button when step=print is loaded via URL

### DIFF
--- a/e2e/nachfassen.spec.ts
+++ b/e2e/nachfassen.spec.ts
@@ -2,6 +2,16 @@ import { test, expect } from '@playwright/test';
 import { screenshotPath } from './screenshot';
 
 const baseUrl = '#{"v":1,"step":"data_info_request","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
+const printUrl = '#{"v":1,"step":"print","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
+
+test('Nachfassen Button erscheint bei direktem URL-Aufruf mit step=print', async ({ page }, testInfo) => {
+  await page.goto(printUrl);
+
+  const nachfassenButton = page.locator('button', { hasText: 'Nachfassen' });
+  await expect(nachfassenButton).toBeVisible();
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-nachfassen-button-print-url.png'), fullPage: true });
+});
 
 test('Nachfassen bei ausbleibender Antwort', async ({ page }, testInfo) => {
   await page.goto(baseUrl);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -180,7 +180,7 @@
     {/if}
     <div class="actions">
       <button class="one no-print" onclick={() => setStep({detail: 'entry'})}>{$_('nav.back_to_entry', { default: '❮ zur Dateneingabe' })}</button>
-      {#if $userData.step === 'data_info_request'}
+      {#if $userData.step === 'data_info_request' || ($userData.step === 'print' && ($userData.entry !== 'followup' || $userData.desire === 'data_info_request'))}
         <button class="one no-print" onclick={hideUnhideFollowUp}>{$_('nav.followup', { default: 'Nachfassen' })}</button>
       {/if}
       <button class="one no-print" onclick={() => setStep({detail: 'print'})}>{$_('nav.print_now', { default: 'Jetzt drucken ❯' })}</button>


### PR DESCRIPTION
The "Nachfassen" button was only rendered when `step === 'data_info_request'`. When a URL with `step: "print"` was opened directly, the button was missing. Extended the condition to also show the button at the print step for initial data_info_request letters, mirroring the existing visibility logic for the LetterDataInfoReq component.

closes #136 