### PR TITLE
fix(letter): keep editable-variable underline continuous under descen…

### DIFF
--- a/e2e/date.spec.ts
+++ b/e2e/date.spec.ts
@@ -104,3 +104,22 @@ test.describe('VariableInput Datum', () => {
     await page.screenshot({ path: screenshotPath(testInfo, '01-vorausgefuelltes-datum.png'), fullPage: true });
   });
 });
+
+test.describe('Editable-Variable Unterstreichung', () => {
+  // Regression: der Datums-Platzhalter "TT.MM.JJJJ" wurde nur bis "TT.MM"
+  // unterstrichen, weil das "J" (Unterlänge) per text-decoration-skip-ink
+  // die Unterstreichung darunter ausgespart hat.
+  test('Datums-Platzhalter wird durchgehend unterstrichen (skip-ink: none)', async ({ page }) => {
+    const url = '#{"v":1,"entry":"followup","desire":"unanswered","step":"unanswered","name":"","date":"9.6.2026","dataInfoRequestDate":"TT.MM.JJJJ"}';
+    await page.goto(url);
+
+    const span = page.locator('section#letter span.editable-variable[data-label="Datum Begehren"]');
+    await expect(span).toBeVisible();
+    await expect(span).toHaveText('TT.MM.JJJJ');
+
+    const skipInk = await span.evaluate(el =>
+      getComputedStyle(el).getPropertyValue('text-decoration-skip-ink')
+    );
+    expect(skipInk).toBe('none');
+  });
+});

--- a/src/global.css
+++ b/src/global.css
@@ -312,6 +312,10 @@ button.solid.two {
   text-decoration: underline;
   text-decoration-thickness: 3px;
   text-decoration-color: var(--color-one);
+  /* Keep the underline continuous under descending glyphs (e.g. the "J" in
+     the "TT.MM.JJJJ" date placeholder); without this the default skip-ink
+     erases the underline beneath the descenders. */
+  text-decoration-skip-ink: none;
 }
 
 .editable-variable.empty::after {
@@ -322,6 +326,7 @@ button.solid.two {
   text-decoration: underline;
   text-decoration-thickness: 3px;
   text-decoration-color: var(--color-one);
+  text-decoration-skip-ink: none;
 }
 
 @media print {


### PR DESCRIPTION
…ders

The "TT.MM.JJJJ" date placeholder was only underlined up to "TT.MM" because the default `text-decoration-skip-ink: auto` erased the underline beneath the descending "J" glyphs in serif fonts.

- Set `text-decoration-skip-ink: none` on `.editable-variable` and its empty `::after` placeholder so the underline stays continuous
- Add a Playwright regression test asserting the computed skip-ink value

Vorher
<img width="568" height="57" alt="image" src="https://github.com/user-attachments/assets/877bcecd-59d2-4da1-8710-7728cf7ed615" />

Nachher
<img width="569" height="59" alt="image" src="https://github.com/user-attachments/assets/67d32a1d-6c0c-461f-a52a-abae56340b57" />
