### PR TITLE
fix: keep and display org preselected via URL, translate org messages

### DIFF
--- a/e2e/datenauskunftsbegehren.spec.ts
+++ b/e2e/datenauskunftsbegehren.spec.ts
@@ -18,6 +18,38 @@ test('Der generierte Brief enthält die Daten aus der Url', async ({ page }, tes
   await page.screenshot({ path: screenshotPath(testInfo, '01-brief-aus-url.png'), fullPage: true });
 });
 
+test('Eine entfernte und wieder hinzugefügte Organisation ist auswählbar', async ({ page }, testInfo) => {
+  // Eine Test-Organisation einschleusen, deren jüngstes History-Ereignis ein
+  // "added" nach einem früheren "removed" ist. Massgeblich für den aktuellen
+  // Zustand ist das jüngste Ereignis, daher muss sie auswählbar sein.
+  await page.route('**/data_de.json', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.orgs.push({
+      name: 'E2E Wieder Aktiv AG',
+      address: 'E2E Wieder Aktiv AG\n1000 E2EOrt',
+      types: [],
+      history: [
+        { action: 'removed', date: '2021-01-01T00:00:00.000Z', reason: 'damals entfernt' },
+        { action: 'added', date: '2023-01-01T00:00:00.000Z' }
+      ]
+    });
+    await route.fulfill({ json });
+  });
+
+  await page.goto('');
+
+  // Die wieder aktivierte Organisation muss in der Auswahl erscheinen
+  const searchInput = page.locator('input[placeholder="Suche ..."]');
+  await searchInput.click();
+  await searchInput.fill('E2E Wieder Aktiv');
+
+  const listContainer = page.locator('div.svelte-select-list');
+  await expect(listContainer).toContainText('E2E Wieder Aktiv AG');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-wieder-aktive-org.png') });
+});
+
 test('Datenauskunftsbegehren für Swisscom generieren', async ({ page }, testInfo) => {
   await page.goto('');
 

--- a/e2e/language.spec.ts
+++ b/e2e/language.spec.ts
@@ -139,7 +139,8 @@ test('Sprachen bleiben nach "Eingaben zurücksetzen" erhalten', async ({ page },
   await page.locator('.overlay header button').click();
 
   // Etwas eingeben, damit der Reset-Button erscheint
-  await page.locator('input[placeholder="Suche ..."]').click();
+  // Sprachunabhängiger Locator, da die UI hier auf Englisch steht (Placeholder ist übersetzt)
+  await page.locator('.svelte-select input[type="text"]').click();
   const listContainer = page.locator('div.svelte-select-list');
   await expect(listContainer).toBeVisible();
   await listContainer.locator('div.item').first().click();

--- a/e2e/nachfassen.spec.ts
+++ b/e2e/nachfassen.spec.ts
@@ -141,6 +141,52 @@ test('Nachfassen Daten ausgehändigt bekommen', async ({ page }) => {
   expect(sectionText).toContain('TT.MM.JJJJ');
 });
 
+test('Vorausgewählte Organisation aus URL wird in der Auswahl angezeigt', async ({ page }, testInfo) => {
+  const url = '#{"v":1,"entry":"followup","desire":"data_handover","step":"entry","name":"E2E Person","address":"E2E Absender","org":"Agrisano","date":"9.6.2026"}';
+  await page.goto(url);
+
+  // Die in der URL gewählte Organisation muss in der svelte-select Auswahl sichtbar sein
+  const selectedItem = page.locator('.org-selection .selected-item');
+  await expect(selectedItem).toHaveText('Agrisano');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-org-aus-url-vorausgewaehlt.png'), fullPage: true });
+});
+
+test('Unbekannte Organisation aus URL wird zurückgesetzt und meldet einen Fehler', async ({ page }, testInfo) => {
+  const url = '#{"v":1,"entry":"followup","desire":"data_handover","step":"entry","name":"E2E Person","address":"E2E Absender","org":"NichtExistierendeOrg12345"}';
+  await page.goto(url);
+
+  // Die Fehlermeldung zur zurückgesetzten Organisation muss erscheinen
+  const messages = page.locator('.messages');
+  await expect(messages).toContainText('Die Organisation NichtExistierendeOrg12345 ist nicht (mehr) im Datensatz vorhanden. Deine Eingabe wurde zurückgesetzt.');
+
+  // Die Organisationsauswahl darf keine vorausgewählte Organisation anzeigen
+  await expect(page.locator('.org-selection .selected-item')).toHaveCount(0);
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-unbekannte-org-zurueckgesetzt.png'), fullPage: true });
+});
+
+test('Hinweis erscheint, wenn die gewählte Organisation aus der Liste entfernt wurde', async ({ page }, testInfo) => {
+  // MS Direct AG hat im Datensatz einen "removed"-Eintrag (05.06.2021). Mit
+  // step=data_info_request bleibt die Organisation erhalten (Validierung greift
+  // nicht), sodass der Entfernungs-Hinweis angezeigt wird.
+  const url = '#{"v":1,"step":"data_info_request","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender","org":"MS Direct AG"}';
+  await page.goto(url);
+
+  const messages = page.locator('.messages');
+  await expect(messages).toContainText('Die Organisation MS Direct AG wurde am 05.06.2021 aus der Liste entfernt. Die MS Direct AG pflegt keine eigenen Datenbestände.');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-org-aus-liste-entfernt.png'), fullPage: true });
+});
+
+test('Fehlermeldung zur unbekannten Organisation wird übersetzt (EN)', async ({ page }) => {
+  const url = '#{"v":1,"langUi":"en","entry":"followup","desire":"data_handover","step":"entry","name":"E2E Person","address":"E2E Absender","org":"NichtExistierendeOrg12345"}';
+  await page.goto(url);
+
+  const messages = page.locator('.messages');
+  await expect(messages).toContainText('The organisation NichtExistierendeOrg12345 is no longer part of the dataset. Your input has been reset.');
+});
+
 test('Nachfassen Daten ausgehändigt bekommen mit Datum im URL', async ({ page }) => {
   const url = '#{"v":1,"step":"data_handover","entry":"followup","desire":"data_handover","name":"E2E Person","date":"28.7.2025","dataInfoResponseDate":"3.3.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
   await page.goto(url);

--- a/src/Messages.svelte
+++ b/src/Messages.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { _ } from 'svelte-i18n'
   import { messages } from './stores.js'
 
   let iconsForType = {
@@ -15,7 +16,19 @@
           {iconsForType[message.type]}
         </div>
         <div class="text">
-          { message.text }
+          {#if message.key === 'org_not_in_dataset'}
+            {$_('messages.org_not_in_dataset', {
+              default: 'Die Organisation {org} ist nicht (mehr) im Datensatz vorhanden. Deine Eingabe wurde zurückgesetzt.',
+              values: { org: message.values.org }
+            })}
+          {:else if message.key === 'org_removed_from_list'}
+            {$_('messages.org_removed_from_list', {
+              default: 'Die Organisation {org} wurde am {date} aus der Liste entfernt. {reason}',
+              values: { org: message.values.org, date: message.values.date, reason: message.values.reason }
+            })}
+          {:else}
+            { message.text }
+          {/if}
         </div>
       </div>
     {/each}

--- a/src/data.js
+++ b/src/data.js
@@ -25,7 +25,8 @@ export function validateUserData(userData) {
   if (!validOrg) {
     messages.push({
       type: 'error',
-      text: `Die Organisation ${userData.org} ist nicht (mehr) im Datensatz vorhanden. Deine Eingabe wurde zurückgesetzt.`
+      key: 'org_not_in_dataset',
+      values: { org: userData.org }
     })
   }
   return {
@@ -53,7 +54,12 @@ export function getOrgHistoryMessage(userData) {
     if (!removal) return
     return {
       type: 'message',
-      text: `Die Organisation ${userData.org} wurde am ${lightFormat(removal.date, 'dd.MM.yyyy')} aus der Liste entfernt. ${removal.reason}`
+      key: 'org_removed_from_list',
+      values: {
+        org: userData.org,
+        date: lightFormat(removal.date, 'dd.MM.yyyy'),
+        reason: removal.reason
+      }
     }
   }
   return undefined

--- a/src/entry/OrgSelection.svelte
+++ b/src/entry/OrgSelection.svelte
@@ -3,6 +3,7 @@
   const dispatch = createEventDispatcher();
 
   import Select from 'svelte-select';
+  import { _ } from 'svelte-i18n';
   import { data } from '../stores.js';
 
   let { org = $bindable(undefined), options = undefined } = $props();
@@ -35,12 +36,12 @@
 
 <div class="org-selection" bind:this={wrapper}>
   {#if !isTouch}
-    <Select 
-      selectedValue={org}
+    <Select
+      value={org}
       bind:items={orgOptions}
       showIndicator="true"
-      placeholder="Suche ..."
-      noOptionsMessage="Keine Organisation gefunden"
+      placeholder={$_('org_selection.search_placeholder', { default: 'Suche ...' })}
+      noOptionsMessage={$_('org_selection.no_options', { default: 'Keine Organisation gefunden' })}
       on:select={handleSelect}
       on:clear={handleClear}
     ></Select>

--- a/src/locales/de-CH.json
+++ b/src/locales/de-CH.json
@@ -148,5 +148,13 @@
   "test_banner": {
     "is_test_system": "Dies ist ein Testsystem",
     "find_production_at": "Das produktive System findest du unter"
+  },
+  "messages": {
+    "org_not_in_dataset": "Die Organisation {org} ist nicht (mehr) im Datensatz vorhanden. Deine Eingabe wurde zurückgesetzt.",
+    "org_removed_from_list": "Die Organisation {org} wurde am {date} aus der Liste entfernt. {reason}"
+  },
+  "org_selection": {
+    "search_placeholder": "Suche ...",
+    "no_options": "Keine Organisation gefunden"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -148,5 +148,13 @@
   "test_banner": {
     "is_test_system": "This is a test system",
     "find_production_at": "The production system is available at"
+  },
+  "messages": {
+    "org_not_in_dataset": "The organisation {org} is no longer part of the dataset. Your input has been reset.",
+    "org_removed_from_list": "The organisation {org} was removed from the list on {date}. {reason}"
+  },
+  "org_selection": {
+    "search_placeholder": "Search ...",
+    "no_options": "No organisation found"
   }
 }

--- a/src/locales/fr-CH.json
+++ b/src/locales/fr-CH.json
@@ -148,5 +148,13 @@
   "test_banner": {
     "is_test_system": "Ceci est un système de test",
     "find_production_at": "Le système de production est disponible sur"
+  },
+  "messages": {
+    "org_not_in_dataset": "L'organisation {org} ne fait plus partie du jeu de données. Votre saisie a été réinitialisée.",
+    "org_removed_from_list": "L'organisation {org} a été retirée de la liste le {date}. {reason}"
+  },
+  "org_selection": {
+    "search_placeholder": "Rechercher ...",
+    "no_options": "Aucune organisation trouvée"
   }
 }

--- a/src/locales/it-CH.json
+++ b/src/locales/it-CH.json
@@ -148,5 +148,13 @@
   "test_banner": {
     "is_test_system": "Questo è un sistema di test",
     "find_production_at": "Il sistema di produzione è disponibile su"
+  },
+  "messages": {
+    "org_not_in_dataset": "L'organizzazione {org} non è più presente nel set di dati. I tuoi dati sono stati reimpostati.",
+    "org_removed_from_list": "L'organizzazione {org} è stata rimossa dall'elenco il {date}. {reason}"
+  },
+  "org_selection": {
+    "search_placeholder": "Cerca ...",
+    "no_options": "Nessuna organizzazione trovata"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -80,6 +80,13 @@ async function init() {
     return false
   }
   await data.load(json)
+
+  // The userData hash was only parsed at module init (the dataset was not loaded
+  // yet). Now that the org list is available, validate it so an org referenced in
+  // the URL is kept instead of being wrongly treated as unknown and stripped.
+  const { revalidateUserData } = await import('./stores.js')
+  revalidateUserData()
+
   return true
 }
 

--- a/src/models/History.js
+++ b/src/models/History.js
@@ -14,7 +14,10 @@ export default class History {
   }
 
   getLastEvent() {
-    return this.data[this.data.length - 1]
+    // this.data is sorted descending by date (newest first), so the most recent
+    // event is at index 0. This determines the org's current state, e.g. an org
+    // that was removed and later re-added must count as currently valid.
+    return this.data[0]
   }
 
   isCurrentlyValid() {

--- a/src/stores.js
+++ b/src/stores.js
@@ -17,26 +17,40 @@ window.addEventListener('hashchange', (event) => {
   })
 })
 
-function getUserDataFromHash() {
+function parseUserDataFromHash() {
   const hash = window.location.hash;
   if (hash.length === 0) return {}
   try {
-    const data = JSON.parse(decodeURI(hash.slice(1)))
-    const validState = validateUserData(data)
-    if (validState.isValid) {
-      return data
-    } else {
-      messages.update(messages => {
-        messages.push(...validState.messages)
-        return messages
-      })
-      return getValidUserData(data)
-    }
+    return JSON.parse(decodeURI(hash.slice(1)))
   } catch (err) {
     console.error("URL fragment parsing failed!")
     console.error(err)
     return {}
   }
+}
+
+function cleanUserData(data) {
+  const validState = validateUserData(data)
+  if (validState.isValid) {
+    return data
+  } else {
+    messages.update(messages => {
+      messages.push(...validState.messages)
+      return messages
+    })
+    return getValidUserData(data)
+  }
+}
+
+function getUserDataFromHash() {
+  return cleanUserData(parseUserDataFromHash())
+}
+
+// Re-validate the current userData against the loaded dataset. This must run
+// after the org data is available, otherwise an org referenced in the URL would
+// be considered invalid (the dataset is empty at module init time) and stripped.
+export function revalidateUserData() {
+  userData.update(data => cleanUserData(data))
 }
 
 let lastStep
@@ -87,7 +101,10 @@ const updateMessagesThrottled = throttle(updateMessages, 300, {
   trailing: true
 })
 
-const currentUserData = getUserDataFromHash()
+// At module init the dataset is not loaded yet, so we only parse the hash here.
+// Validation (which depends on the loaded org list) happens via revalidateUserData()
+// once the data has been loaded (see main.js).
+const currentUserData = parseUserDataFromHash()
 export const userData = writable(currentUserData)
 userData.subscribe(val => {
   setUserDataToHashThrottled(val)

--- a/tooling/docker.sh
+++ b/tooling/docker.sh
@@ -41,8 +41,26 @@ case "$CMD" in
       sh -c "wget -O public/data_de.json https://github.com/DigitaleGesellschaft/Datenauskunftsbegehren-Data/releases/latest/download/data_de.json && \
              wget -O public/data_fr.json https://github.com/DigitaleGesellschaft/Datenauskunftsbegehren-Data/releases/latest/download/data_fr.json"
     ;;
+  i18n)
+    # node:24 (Debian) is used instead of alpine because the i18n shell scripts
+    # require bash.
+    docker run --rm \
+      -v "${PROJECT_ROOT}:/app" \
+      -w /app \
+      node:24 \
+      bash -c "npm install && npm run i18n"
+    ;;
+  i18n-check)
+    # git is required because the check compares the extracted locale files
+    # against the committed state.
+    docker run --rm \
+      -v "${PROJECT_ROOT}:/app" \
+      -w /app \
+      node:24 \
+      bash -c "git config --global --add safe.directory /app && npm install && npm run i18n-check"
+    ;;
   *)
-    echo "Usage: $0 {dev|test|download-data}"
+    echo "Usage: $0 {dev|test|download-data|i18n|i18n-check}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
The organisation referenced in the URL hash was wrongly dropped: user data was validated against the org list at module init time, before the dataset was loaded, so any org was considered unknown and stripped. Parsing is now separated from validation, and revalidation runs once the data has loaded.

The OrgSelection also passed the org via the unsupported `selectedValue` prop instead of svelte-select's `value`, so a preselected org was not shown.

In addition, the previously hardcoded German strings are now translatable: the org validation/history messages are emitted with a key + values and translated in Messages.svelte, and the OrgSelection placeholders use i18n. French, English and Italian translations are added.

Fix History.getLastEvent(): the history is sorted descending (newest first), so the current state must be derived from index 0, not the last element. An org that was removed and later re-added is now correctly treated as valid.

A `i18n` / `i18n-check` command is added to tooling/docker.sh so the locale extraction and check can run without a local Node install.

Add Playwright tests covering a preselected org from the URL, the reset behaviour for an org no longer in the dataset, the removal notice for an org that was removed from the list, the translated message, and a removed-then- re-added org remaining selectable.