### PR TITLE
fix: detect UI language from browser locale on first load

### DIFF
--- a/e2e/language.spec.ts
+++ b/e2e/language.spec.ts
@@ -68,6 +68,36 @@ for (const lang of languages) {
   });
 }
 
+test.describe('Browsersprache Englisch', () => {
+  test.use({ locale: 'en-US' });
+
+  test('Englischer Browser ohne Hash: UI und langUi sind Englisch', async ({ page }, testInfo) => {
+    await page.goto('');
+
+    // Die Oberfläche wird auf Englisch dargestellt
+    await expect(page.locator('h1')).toHaveText('Generate your data access request');
+
+    // langUi muss als Englisch erkannt und in die URL geschrieben werden (nicht "de")
+    await expect
+      .poll(async () => {
+        const hash = await page.evaluate(() => window.location.hash);
+        try {
+          return JSON.parse(decodeURIComponent(hash.slice(1))).langUi;
+        } catch {
+          return undefined;
+        }
+      })
+      .toBe('en');
+
+    // Im Sprachwähler ist konsequenterweise "English" vorausgewählt
+    await page.locator('button.circle.one').first().click();
+    await expect(page.locator('input[name="ui-language"][value="en"]')).toBeChecked();
+    await expect(page.locator('input[name="ui-language"][value="de"]')).not.toBeChecked();
+
+    await page.screenshot({ path: screenshotPath(testInfo, '01-englischer-browser.png'), fullPage: true });
+  });
+});
+
 const letterSnippets = {
   de: {
     registeredMail: 'EINSCHREIBEN',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -9,9 +9,11 @@ register('it', () => import('./locales/it-CH.json'));
 addMessages('de-letter', deCHLetter);
 addMessages('fr-letter', frCHLetter);
 
-const SUPPORTED_LANGS = ['de', 'fr', 'en', 'it'];
+export const SUPPORTED_LANGS = ['de', 'fr', 'en', 'it'];
 
-function getInitialLocale() {
+const DEFAULT_LANG = import.meta.env.VITE_DEFAULT_LANG || 'de';
+
+export function getInitialLocale() {
   const hash = window.location.hash;
   if (hash.length > 0) {
     try {
@@ -19,11 +21,20 @@ function getInitialLocale() {
       if (SUPPORTED_LANGS.includes(data.langUi)) return data.langUi;
     } catch {}
   }
-  return getLocaleFromNavigator();
+  // Normalize the navigator locale (e.g. "en-US") to a supported language ("en").
+  // svelte-i18n loads locale messages asynchronously, so the `locale` store is
+  // not yet populated when the stores module initializes — callers therefore
+  // need this synchronous detection instead of reading `locale`.
+  const navLocale = getLocaleFromNavigator();
+  if (navLocale) {
+    const base = navLocale.toLowerCase().split('-')[0];
+    if (SUPPORTED_LANGS.includes(base)) return base;
+  }
+  return DEFAULT_LANG;
 }
 
 init({
-  fallbackLocale: import.meta.env.VITE_DEFAULT_LANG || 'de',
+  fallbackLocale: DEFAULT_LANG,
   initialLocale: getInitialLocale(),
   ignoreTag: false
 });

--- a/src/stores.js
+++ b/src/stores.js
@@ -6,6 +6,7 @@ import {nl2br, br2nl} from './lib.js'
 import { throttle } from 'lodash-es';
 import {data as d, validateUserData, getValidUserData, getOrgHistoryMessage} from './data.js';
 import { _, locale } from 'svelte-i18n';
+import { getInitialLocale } from './i18n.js';
 
 const _dataStore = writable(d)
 export const data = { subscribe: _dataStore.subscribe }
@@ -166,7 +167,7 @@ const currentImages = get(userData).idImages ? get(userData).idImages : {
 
 export const idImages = writable(currentImages)
 
-export const langUi = writable(currentUserData.langUi || get(locale) || DEFAULT_LANG)
+export const langUi = writable(currentUserData.langUi || getInitialLocale())
 
 langUi.subscribe(lang => {
   locale.set(lang)


### PR DESCRIPTION
`langUi` was initialized from svelte-i18n's `locale` store, which is still empty at store-init time because locale messages load asynchronously. As a result the UI language always defaulted to `de` for visitors with a non-German browser (e.g. English), persisting `langUi:"de"` in the URL even though the interface rendered in English.

`langUi` now uses the same synchronous navigator-based detection as the i18n init (`getInitialLocale`, exported from `i18n.js`), normalizing locales like `en-US` to a supported language. Added a Playwright test covering an English browser without a hash.

Fixes #150