### PR TITLE
feat(letter): translate date placeholders with correspondence language

### DIFF
--- a/e2e/date.spec.ts
+++ b/e2e/date.spec.ts
@@ -186,6 +186,23 @@ test.describe('Datumsplatzhalter Übersetzung', () => {
     await expect(page.locator('#letter')).toContainText('15.06.2099');
     await expect(page).toHaveURL(/15\.06\.2099/);
   });
+
+  test('Ein eingegebenes ISO-Datum (2020-02-20) bleibt beim Sprachwechsel erhalten', async ({ page }) => {
+    // Es werden nur Werte ersetzt, die exakt einem bekannten Platzhalter
+    // (TT.MM.JJJJ / JJ.MM.AAAA) entsprechen. Ein ISO-Datum ist kein Platzhalter
+    // und bleibt deshalb unverändert.
+    await page.goto(`#${demandHash('de', 'de', { dataInfoRequestDate: '2020-02-20' })}`);
+
+    await expect(page.locator('#letter')).toContainText('2020-02-20');
+
+    // Korrespondenzsprache auf Französisch umstellen
+    await page.locator('button.circle.one').first().click();
+    await page.locator('input[name="correspondence-language"][value="fr"]').click();
+
+    // Das ISO-Datum bleibt unverändert (kein Platzhalter-Match → User gewinnt)
+    await expect(page.locator('#letter')).toContainText('2020-02-20');
+    await expect(page).toHaveURL(/2020-02-20/);
+  });
 });
 
 test.describe('Editable-Variable Unterstreichung', () => {

--- a/e2e/date.spec.ts
+++ b/e2e/date.spec.ts
@@ -104,3 +104,86 @@ test.describe('VariableInput Datum', () => {
     await page.screenshot({ path: screenshotPath(testInfo, '01-vorausgefuelltes-datum.png'), fullPage: true });
   });
 });
+
+test.describe('Datumsplatzhalter Übersetzung', () => {
+  function demandHash(langUi: string, langCor: string, extra: Record<string, unknown> = {}): string {
+    return encodeURI(
+      JSON.stringify({
+        step: 'incomplete_answer',
+        entry: 'followup',
+        desire: 'incomplete_answer',
+        langUi,
+        langCor,
+        v: 1,
+        ...extra,
+      }),
+    );
+  }
+
+  // Erwartetes Platzhalter-Format je Korrespondenzsprache (Briefsprache: nur de/fr)
+  const placeholderByLang = {
+    de: 'TT.MM.JJJJ',
+    fr: 'JJ.MM.AAAA',
+  };
+
+  for (const [lang, placeholder] of Object.entries(placeholderByLang)) {
+    test(`Platzhalter-Format für Korrespondenzsprache «${lang}» ist ${placeholder}`, async ({ page }) => {
+      await page.goto(`#${demandHash('de', lang)}`);
+
+      await expect(page.locator('#letter')).toContainText(placeholder);
+
+      // Kein Platzhalter einer anderen Sprache ist vorhanden
+      for (const [otherLang, otherPlaceholder] of Object.entries(placeholderByLang)) {
+        if (otherLang !== lang) {
+          await expect(page.locator('#letter')).not.toContainText(otherPlaceholder);
+        }
+      }
+    });
+  }
+
+  test('Wechsel der Korrespondenzsprache übersetzt die Platzhalter (Brief und URL)', async ({ page }, testInfo) => {
+    await page.goto(`#${demandHash('de', 'de')}`);
+
+    // Platzhalter ist zunächst auf Deutsch — im Brief und in der URL
+    await expect(page.locator('#letter')).toContainText('TT.MM.JJJJ');
+    await expect(page).toHaveURL(/TT\.MM\.JJJJ/);
+
+    await page.screenshot({ path: screenshotPath(testInfo, '01-platzhalter-deutsch.png'), fullPage: true });
+
+    // Korrespondenzsprache auf Französisch umstellen
+    await page.locator('button.circle.one').first().click();
+    await page.locator('input[name="correspondence-language"][value="fr"]').click();
+
+    // Platzhalter ist nun auf Französisch — im Brief und in der URL
+    await expect(page.locator('#letter')).toContainText('JJ.MM.AAAA');
+    await expect(page.locator('#letter')).not.toContainText('TT.MM.JJJJ');
+    await expect(page).toHaveURL(/JJ\.MM\.AAAA/);
+    await expect(page).not.toHaveURL(/TT\.MM\.JJJJ/);
+
+    await page.screenshot({ path: screenshotPath(testInfo, '02-platzhalter-franzoesisch.png'), fullPage: true });
+
+    // Zurück auf Deutsch wechseln — Platzhalter wird wieder übersetzt
+    await page.locator('input[name="correspondence-language"][value="de"]').click();
+
+    await expect(page.locator('#letter')).toContainText('TT.MM.JJJJ');
+    await expect(page.locator('#letter')).not.toContainText('JJ.MM.AAAA');
+    await expect(page).toHaveURL(/TT\.MM\.JJJJ/);
+    await expect(page).not.toHaveURL(/JJ\.MM\.AAAA/);
+  });
+
+  test('Ein echtes, eingegebenes Datum bleibt beim Sprachwechsel erhalten', async ({ page }) => {
+    // Echtes Datum direkt über die URL setzen (zuverlässiger als Tippen ins contenteditable)
+    await page.goto(`#${demandHash('de', 'de', { dataInfoRequestDate: '15.06.2099' })}`);
+
+    await expect(page.locator('#letter')).toContainText('15.06.2099');
+
+    // Korrespondenzsprache auf Französisch umstellen
+    await page.locator('button.circle.one').first().click();
+    await page.locator('input[name="correspondence-language"][value="fr"]').click();
+
+    // Das echte Datum bleibt unverändert, es wird nicht durch einen Platzhalter ersetzt.
+    // (Das noch leere Antwort-Datumsfeld wird hingegen zu JJ.MM.AAAA übersetzt.)
+    await expect(page.locator('#letter')).toContainText('15.06.2099');
+    await expect(page).toHaveURL(/15\.06\.2099/);
+  });
+});

--- a/src/letter/LetterDataInfoReqChange.svelte
+++ b/src/letter/LetterDataInfoReqChange.svelte
@@ -3,7 +3,7 @@
 
   import {onMount} from 'svelte';
   import HideNodeAction from './HideNodeAction.svelte';
-  import {data, orgAddressHtml, userAddressHtml, userData} from '../stores.js';
+  import {data, getDatePlaceholder, orgAddressHtml, userAddressHtml, userData} from '../stores.js';
   import {nl2br} from '../lib.js';
 
   let LetterDataInfoReqChangeNode = $state()
@@ -31,7 +31,7 @@
       })
     }
     if (!$userData.dataInfoResponseDate || $userData.dataInfoResponseDate === '' || $userData.dataInfoResponseDate === '<br>') {
-      userData.update(ud => { ud.dataInfoResponseDate = 'TT.MM.JJJJ'; return ud })
+      userData.update(ud => { ud.dataInfoResponseDate = getDatePlaceholder(); return ud })
     }
 
     customOpening = $userData.customOpening ? $data.getCustomOpening($userData.customOpening) : undefined

--- a/src/letter/LetterDataInfoReqDelete.svelte
+++ b/src/letter/LetterDataInfoReqDelete.svelte
@@ -1,7 +1,7 @@
 <script>
   import {onMount} from 'svelte';
   import HideNodeAction from './HideNodeAction.svelte';
-  import {data, orgAddressHtml, userAddressHtml, userData} from '../stores.js';
+  import {data, getDatePlaceholder, orgAddressHtml, userAddressHtml, userData} from '../stores.js';
   import {nl2br} from '../lib.js';
   import { c as _ } from '../stores.js';
 
@@ -30,7 +30,7 @@
       })
     }
     if (!$userData.dataInfoResponseDate || $userData.dataInfoResponseDate === '' || $userData.dataInfoResponseDate === '<br>') {
-      userData.update(ud => { ud.dataInfoResponseDate = 'TT.MM.JJJJ'; return ud })
+      userData.update(ud => { ud.dataInfoResponseDate = getDatePlaceholder(); return ud })
     }
 
     customOpening = $userData.customOpening ? $data.getCustomOpening($userData.customOpening) : undefined

--- a/src/letter/LetterDataInfoReqDemand.svelte
+++ b/src/letter/LetterDataInfoReqDemand.svelte
@@ -2,7 +2,7 @@
   import {onMount} from 'svelte';
   import { c as _ } from '../stores.js';
   import HideNodeAction from './HideNodeAction.svelte';
-  import {data, orgAddressHtml, userAddressHtml, userData} from '../stores.js';
+  import {data, getDatePlaceholder, orgAddressHtml, userAddressHtml, userData} from '../stores.js';
   import {nl2br} from '../lib.js';
 
   // Unvollständige Auskunft
@@ -32,10 +32,10 @@
       })
     }
     if (!$userData.dataInfoRequestDate || $userData.dataInfoRequestDate === '' || $userData.dataInfoRequestDate === '<br>') {
-      userData.update(ud => { ud.dataInfoRequestDate = 'TT.MM.JJJJ'; return ud })
+      userData.update(ud => { ud.dataInfoRequestDate = getDatePlaceholder(); return ud })
     }
     if (!$userData.dataInfoResponseDate || $userData.dataInfoResponseDate === '' || $userData.dataInfoResponseDate === '<br>') {
-      userData.update(ud => { ud.dataInfoResponseDate = 'TT.MM.JJJJ'; return ud })
+      userData.update(ud => { ud.dataInfoResponseDate = getDatePlaceholder(); return ud })
     }
 
     customOpening = $userData.customOpening ? $data.getCustomOpening($userData.customOpening) : undefined

--- a/src/letter/LetterDataInfoReqHandover.svelte
+++ b/src/letter/LetterDataInfoReqHandover.svelte
@@ -2,7 +2,7 @@
   import {onMount} from 'svelte';
   import { c as _ } from '../stores.js';
   import HideNodeAction from './HideNodeAction.svelte';
-  import {data, orgAddressHtml, userAddressHtml, userData} from '../stores.js';
+  import {data, getDatePlaceholder, orgAddressHtml, userAddressHtml, userData} from '../stores.js';
   import {nl2br} from '../lib.js';
 
   // Herausgabe von Daten nach erteilter Auskunft
@@ -31,7 +31,7 @@
       })
     }
     if (!$userData.dataInfoResponseDate || $userData.dataInfoResponseDate === '' || $userData.dataInfoResponseDate === '<br>') {
-      userData.update(ud => { ud.dataInfoResponseDate = 'TT.MM.JJJJ'; return ud })
+      userData.update(ud => { ud.dataInfoResponseDate = getDatePlaceholder(); return ud })
     }
 
     customOpening = $userData.customOpening ? $data.getCustomOpening($userData.customOpening) : undefined

--- a/src/letter/LetterDataInfoReqRemind.svelte
+++ b/src/letter/LetterDataInfoReqRemind.svelte
@@ -2,7 +2,7 @@
   import {onMount} from 'svelte';
   import { c as _ } from '../stores.js';
   import HideNodeAction from './HideNodeAction.svelte';
-  import {data, orgAddressHtml, userAddressHtml, userData} from '../stores.js';
+  import {data, getDatePlaceholder, orgAddressHtml, userAddressHtml, userData} from '../stores.js';
   import {nl2br} from '../lib.js';
 
   // Ausbleibende Auskunft
@@ -32,7 +32,7 @@
       })
     }
     if (!$userData.dataInfoRequestDate || $userData.dataInfoRequestDate === '' || $userData.dataInfoRequestDate === '<br>') {
-      userData.update(ud => { ud.dataInfoRequestDate = 'TT.MM.JJJJ'; return ud })
+      userData.update(ud => { ud.dataInfoRequestDate = getDatePlaceholder(); return ud })
     }
 
     customOpening = $userData.customOpening ? $data.getCustomOpening($userData.customOpening) : undefined

--- a/src/locales/de-CH.letter.json
+++ b/src/locales/de-CH.letter.json
@@ -4,6 +4,7 @@
   "date": "Datum",
   "date_of_request_label": "Datum Begehren",
   "date_of_response_label": "Datum Antwort",
+  "date_placeholder": "TT.MM.JJJJ",
   "toggle_visibility": "Ein-/ausblenden",
   "recipient_address": "Empfängeradresse",
   "registered_mail": "EINSCHREIBEN",

--- a/src/locales/fr-CH.letter.json
+++ b/src/locales/fr-CH.letter.json
@@ -4,6 +4,7 @@
   "date": "Date",
   "date_of_request_label": "Date de la requête",
   "date_of_response_label": "Date de la réponse",
+  "date_placeholder": "JJ.MM.AAAA",
   "toggle_visibility": "Ouvrir/fermer",
   "recipient_address": "Adresse du destinataire",
   "registered_mail": "RECOMMANDÉ",

--- a/src/stores.js
+++ b/src/stores.js
@@ -186,8 +186,12 @@ export const langCor = writable(currentUserData.langCor || DEFAULT_COR_LANG)
 
 let initialLangCorLoad = true
 langCor.subscribe(async lang => {
+  const isInitial = initialLangCorLoad
   userData.update(ud => {
     ud.langCor = lang
+    // On a real language switch, re-translate leftover date placeholders.
+    // Skipped on initial load, where letter components set them themselves.
+    if (!isInitial) translateDatePlaceholders(ud, lang)
     return ud
   })
   if (initialLangCorLoad) {
@@ -213,3 +217,27 @@ userData.subscribe(val => {
 export const c = derived([_, langCor], ([t, corrLocale]) => {
   return (key, opts = {}) => t(key, { ...opts, locale: corrLocale + '-letter' })
 })
+
+// Correspondence languages that have a letter locale (see i18n.js)
+const LETTER_LANGS = ['de', 'fr']
+// User data fields that may hold a date placeholder
+const DATE_FIELDS = ['dataInfoRequestDate', 'dataInfoResponseDate']
+
+// Returns the localized date placeholder (e.g. "TT.MM.JJJJ" / "JJ.MM.AAAA")
+export function getDatePlaceholder(lang = get(langCor)) {
+  return get(_)('date_placeholder', { locale: lang + '-letter', default: 'TT.MM.JJJJ' })
+}
+
+// When the correspondence language changes, the date placeholders of the
+// previous language stay in userData (and the URL). Re-translate any field
+// that still holds a placeholder so it matches the new language. Real,
+// user-entered dates are left untouched.
+function translateDatePlaceholders(userData, lang) {
+  const placeholders = LETTER_LANGS.map(l => getDatePlaceholder(l))
+  const newPlaceholder = getDatePlaceholder(lang)
+  for (const field of DATE_FIELDS) {
+    if (placeholders.includes(userData[field])) {
+      userData[field] = newPlaceholder
+    }
+  }
+}


### PR DESCRIPTION
The date placeholders (`dataInfoRequestDate` / `dataInfoResponseDate`) were hardcoded to the German `TT.MM.JJJJ`. When switching the correspondence language the letter text changed, but the placeholders stayed German.

- Add a localized `date_placeholder` key to the letter locales (de: `TT.MM.JJJJ`, fr: `JJ.MM.AAAA`).
- Letter components now seed the placeholder via `getDatePlaceholder()` instead of the hardcoded string.
- When the correspondence language changes, any field still holding a known placeholder is re-translated to the new language (in the letter and the URL). Real, user-entered dates are left untouched.

Adds Playwright tests covering the placeholder format per language (de/fr), the translation on language switch (letter + URL), and that a real date survives a language switch.