### PR TITLE
Fix: Moving final dot so that there is no whitespace

### DIFF
--- a/src/Share.svelte
+++ b/src/Share.svelte
@@ -21,10 +21,10 @@
 </script>
 
 <div class="share">
-  {$_('share.hint', { default: '💡 Die Webadresse (URL) enthält all Deine Eingaben. Du kannst sie speichern' })}
+  {$_('share.hint', { default: '💡 Die Webadresse (URL) enthält all Deine Eingaben. Du kannst sie speichern' })}.
   {#if hasShareApi}
     {$_('share.or_send', { default: 'oder Dir senden:' })} <button class="circle" onclick={share}><ShareIcon></ShareIcon></button>
-  {/if}.
+  {/if}
 </div>
 
 <style>


### PR DESCRIPTION
A whitespace was included at the end of this sentence with the final dot in its current position.
<img width="1793" height="214" alt="image" src="https://github.com/user-attachments/assets/fd8825a2-74a3-48de-a02e-4cee3716f5a7" />

Fix by moving at the end of the sentence and before the share option.