### PR TITLE
feat(print): add GitHub issues link to feedback notice

### DIFF
--- a/commit-message.md
+++ b/commit-message.md
@@ -1,0 +1,4 @@
+feat(print): add GitHub issues link to feedback notice
+
+Extend the feedback text on the print page to also point users to the
+GitHub issues page as an alternative to the support email address.

--- a/e2e/drucken.spec.ts
+++ b/e2e/drucken.spec.ts
@@ -84,6 +84,18 @@ test('Print-Seite zeigt aufgelösten causa-Text ohne Platzhalter', async ({ page
   await expect(sendByPostPara).toContainText('das Datenauskunftsbegehren');
 });
 
+test('Print-Seite verlinkt GitHub Issues neben der E-Mail-Adresse im Feedback-Hinweis', async ({ page }) => {
+  const url = `#{"v":1,"step":"print",${baseState}}`;
+  await page.goto(url);
+
+  const emailLink = page.locator('a[href="mailto:auskunftsbegehren@digitale-gesellschaft.ch"]');
+  await expect(emailLink).toBeVisible();
+
+  const githubLink = page.locator('a[href="https://github.com/DigitaleGesellschaft/Datenauskunftsbegehren/issues"]');
+  await expect(githubLink).toBeVisible();
+  await expect(githubLink).toHaveAttribute('target', '_blank');
+});
+
 test('Brief Auskunftsbegehren via Einstiegsmaske zeigt nur einen Brief', async ({ page }, testInfo) => {
   await page.goto('');
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -36,6 +36,7 @@
 
   const MEMBERSHIP_LINK = 'https://www.digitale-gesellschaft.ch/uber-uns/unterstuetzer-werden/'
   const NEWSLETTER_LINK = 'https://www.digitale-gesellschaft.ch/uber-uns/newsletter/'
+  const GITHUB_ISSUES_LINK = 'https://github.com/DigitaleGesellschaft/Datenauskunftsbegehren/issues'
 
   let normalizedDesire = $derived(
     ($userData.desire === 'letter' ? 'data_info_request' : $userData.desire) || 'data_info_request'
@@ -139,8 +140,11 @@
           <p>{$_('print.deadline_info', { default: 'Ab dem Eingang bleiben 30 Tage für die Beantwortung. Speichere einen Termin im Kalender, um dich für ein allfälliges Nachfragen erinnern zu lassen, falls du bis dahin keine Antwort erhalten hast.' })}</p>
           <IcsDownload></IcsDownload>
           <p>{@html $_('print.feedback', {
-            default: 'Rückmeldungen nehmen wir unter <email_link>auskunftsbegehren@digitale-gesellschaft.ch</email_link> gerne entgegen.',
-            values: { email_link: (text) => `<a href="mailto:auskunftsbegehren@digitale-gesellschaft.ch">${text}</a>` }
+            default: 'Rückmeldungen nehmen wir unter <email_link>auskunftsbegehren@digitale-gesellschaft.ch</email_link> gerne entgegen oder erfasse ein <github_link>Issue auf GitHub.com</github_link>.',
+            values: {
+              email_link: (text) => `<a href="mailto:auskunftsbegehren@digitale-gesellschaft.ch">${text}</a>`,
+              github_link: (text) => `<a target="_blank" rel="noopener noreferrer" href="${GITHUB_ISSUES_LINK}">${text}</a>`
+            }
           })}</p>
           <p>
             {$_('print.support_us_intro', { default: 'Unser Generator wurde von IT- und Rechtskundigen der Digitalen Gesellschaft in unzähligen Stunden entwickelt und steht allen frei zur Verfügung.' })}

--- a/src/locales/de-CH.json
+++ b/src/locales/de-CH.json
@@ -37,7 +37,7 @@
     "done_title": "Geschafft",
     "send_by_post": "Nun musst du {causa} noch <strong>eingeschrieben per Post versenden</strong>.",
     "deadline_info": "Ab dem Eingang bleiben 30 Tage für die Beantwortung. Speichere einen Termin im Kalender, um dich für ein allfälliges Nachfragen erinnern zu lassen, falls du bis dahin keine Antwort erhalten hast.",
-    "feedback": "Rückmeldungen nehmen wir unter <email_link>auskunftsbegehren@digitale-gesellschaft.ch</email_link> gerne entgegen.",
+    "feedback": "Rückmeldungen nehmen wir unter <email_link>auskunftsbegehren@digitale-gesellschaft.ch</email_link> gerne entgegen oder erfasse ein <github_link>Issue auf GitHub.com</github_link>.",
     "support_us_intro": "Unser Generator wurde von IT- und Rechtskundigen der Digitalen Gesellschaft in unzähligen Stunden entwickelt und steht allen frei zur Verfügung.",
     "support_us_membership": "Als <membership_link>Mitglied, Spender oder Gönnerin</membership_link> unterstützt du unsere Arbeit.",
     "support_us_newsletter": "Falls du über unsere Aktivitäten auf dem Laufenden gehalten werden möchtest, abonniere jetzt den <newsletter_link>monatlichen Newsletter</newsletter_link>.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,7 +37,7 @@
     "done_title": "Done!",
     "send_by_post": "You now need to <strong>send {causa} by registered mail</strong>.",
     "deadline_info": "From the date of receipt, 30 days are allowed to respond. Save a calendar entry to remind yourself to follow up in case you haven't received a response by then.",
-    "feedback": "We welcome your feedback at <email_link>auskunftsbegehren@digitale-gesellschaft.ch</email_link>.",
+    "feedback": "We welcome your feedback at <email_link>auskunftsbegehren@digitale-gesellschaft.ch</email_link> or file an <github_link>issue on GitHub.com</github_link>.",
     "support_us_intro": "Our generator was developed by IT and legal experts of the Digital Society in countless hours and is available to everyone for free.",
     "support_us_membership": "As a <membership_link>member, donor or supporter</membership_link>, you support our work.",
     "support_us_newsletter": "To stay up to date on our activities, subscribe to our <newsletter_link>monthly newsletter</newsletter_link> now.",

--- a/src/locales/fr-CH.json
+++ b/src/locales/fr-CH.json
@@ -37,7 +37,7 @@
     "done_title": "C'est fait !",
     "send_by_post": "Tu dois maintenant <strong>envoyer en recommandé par la poste</strong> {causa}.",
     "deadline_info": "Dès réception, 30 jours sont accordés pour répondre. Enregistre un rappel dans le calendrier pour te souvenir de relancer si tu n'as pas reçu de réponse d'ici là.",
-    "feedback": "Tu peux nous faire part de tes remarques à <email_link>auskunftsbegehren@digitale-gesellschaft.ch</email_link>.",
+    "feedback": "Tu peux nous faire part de tes remarques à <email_link>auskunftsbegehren@digitale-gesellschaft.ch</email_link> ou créer une <github_link>issue sur GitHub.com</github_link>.",
     "support_us_intro": "Notre générateur a été développé par des expert·e·s en informatique et en droit de la Société numérique en d'innombrables heures et est mis à disposition gratuitement.",
     "support_us_membership": "En tant que <membership_link>membre, donateur ou donatrice</membership_link>, tu soutiens notre travail.",
     "support_us_newsletter": "Pour rester informé·e de nos activités, abonne-toi dès maintenant à la <newsletter_link>newsletter mensuelle</newsletter_link>.",

--- a/src/locales/it-CH.json
+++ b/src/locales/it-CH.json
@@ -37,7 +37,7 @@
     "done_title": "Fatto!",
     "send_by_post": "Ora devi <strong>inviare {causa} tramite raccomandata</strong>.",
     "deadline_info": "Dalla ricezione, sono concessi 30 giorni per rispondere. Salva un promemoria nel calendario per ricordarti di sollecitare nel caso in cui non dovessi ricevere risposta entro tale termine.",
-    "feedback": "Invia i tuoi commenti a <email_link>auskunftsbegehren@digitale-gesellschaft.ch</email_link>.",
+    "feedback": "Invia i tuoi commenti a <email_link>auskunftsbegehren@digitale-gesellschaft.ch</email_link> oppure apri una <github_link>issue su GitHub.com</github_link>.",
     "support_us_intro": "Il nostro generatore è stato sviluppato da esperti informatici e giuridici della Società digitale in innumerevoli ore ed è disponibile gratuitamente per tutti.",
     "support_us_membership": "Come <membership_link>membro, donatore o donatrice</membership_link>, sostieni il nostro lavoro.",
     "support_us_newsletter": "Per essere aggiornato/a sulle nostre attività, abbonati ora alla <newsletter_link>newsletter mensile</newsletter_link>.",


### PR DESCRIPTION
Extend the feedback text on the print page to also point users to the GitHub issues page as an alternative to the support email address.