### PR TITLE
test: add regression coverage for legacy "letter" URL fallback

### DIFF
--- a/e2e/datenauskunftsbegehren.spec.ts
+++ b/e2e/datenauskunftsbegehren.spec.ts
@@ -18,6 +18,24 @@ test('Der generierte Brief enthält die Daten aus der Url', async ({ page }, tes
   await page.screenshot({ path: screenshotPath(testInfo, '01-brief-aus-url.png'), fullPage: true });
 });
 
+// Regression: ältere Versionen der App verwendeten "letter" statt "data_info_request"
+// als step-Namen. App.svelte fängt das in onMount ab und schreibt den step um, damit
+// alte, geteilte oder als Lesezeichen gespeicherte URLs weiterhin den Brief anzeigen.
+test('Alte URL mit step="letter" zeigt weiterhin den Brief (Regression)', async ({ page }, testInfo) => {
+  const url = '#{"v":1,"step":"letter","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
+  await page.goto(url);
+
+  const letterSection = await page.locator('section#letter');
+  const sectionText = await letterSection.textContent();
+
+  expect(sectionText).toContain('E2E Person');
+  expect(sectionText).toContain('E2E Absender');
+  expect(sectionText).toContain('E2E Empfänger');
+  expect(sectionText).toContain('28.7.2025');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '01-brief-aus-alter-letter-url.png'), fullPage: true });
+});
+
 test('Eine entfernte und wieder hinzugefügte Organisation ist auswählbar', async ({ page }, testInfo) => {
   // Eine Test-Organisation einschleusen, deren jüngstes History-Ereignis ein
   // "added" nach einem früheren "removed" ist. Massgeblich für den aktuellen

--- a/e2e/drucken.spec.ts
+++ b/e2e/drucken.spec.ts
@@ -84,6 +84,20 @@ test('Print-Seite zeigt aufgelösten causa-Text ohne Platzhalter', async ({ page
   await expect(sendByPostPara).toContainText('das Datenauskunftsbegehren');
 });
 
+// Regression: ältere Versionen der App kannten kein "desire" und trugen stattdessen
+// "letter" als step ein. App.svelte normalisiert desire="letter" zu "data_info_request",
+// damit der Causa-Text auf der Druckseite (und im ICS-Export) nicht den rohen
+// Übersetzungsschlüssel "causa.print.letter" anzeigt.
+test('Print-Seite löst causa-Text auch bei altem desire="letter" auf (Regression)', async ({ page }) => {
+  const url = `#{"v":1,"desire":"letter","step":"print",${baseState}}`;
+  await page.goto(url);
+
+  const sendByPostPara = page.locator('.step-print p').first();
+  await expect(sendByPostPara).not.toContainText('{causa}');
+  await expect(sendByPostPara).not.toContainText('causa.print.letter');
+  await expect(sendByPostPara).toContainText('das Datenauskunftsbegehren');
+});
+
 test('Brief Auskunftsbegehren via Einstiegsmaske zeigt nur einen Brief', async ({ page }, testInfo) => {
   await page.goto('');
 


### PR DESCRIPTION
Add Playwright tests covering the backward-compatibility fallbacks that translate legacy `step`/`desire: "letter"` URL values (used before the step was renamed to `data_info_request`) into the current naming, so old bookmarked/shared URLs keep working and the print-page causa text doesn't leak a raw translation key.