### PR TITLE
fix(letter): fix broken bullet visibility toggle

### DIFF
--- a/e2e/date.spec.ts
+++ b/e2e/date.spec.ts
@@ -91,7 +91,7 @@ test.describe('VariableInput Datum', () => {
     const generateButton = page.locator('button', { hasText: 'Brief generieren' });
     await generateButton.click();
 
-    await expect(page.locator('section#letter')).toContainText('15.06.2099');
+    await expect(page.locator('[data-qa="letter"]')).toContainText('15.06.2099');
 
     await page.screenshot({ path: screenshotPath(testInfo, '01-datum-konvertiert-brief.png'), fullPage: true });
   });
@@ -130,12 +130,12 @@ test.describe('Datumsplatzhalter Übersetzung', () => {
     test(`Platzhalter-Format für Korrespondenzsprache «${lang}» ist ${placeholder}`, async ({ page }) => {
       await page.goto(`#${demandHash('de', lang)}`);
 
-      await expect(page.locator('#letter')).toContainText(placeholder);
+      await expect(page.locator('[data-qa="letter"]')).toContainText(placeholder);
 
       // Kein Platzhalter einer anderen Sprache ist vorhanden
       for (const [otherLang, otherPlaceholder] of Object.entries(placeholderByLang)) {
         if (otherLang !== lang) {
-          await expect(page.locator('#letter')).not.toContainText(otherPlaceholder);
+          await expect(page.locator('[data-qa="letter"]')).not.toContainText(otherPlaceholder);
         }
       }
     });
@@ -145,7 +145,7 @@ test.describe('Datumsplatzhalter Übersetzung', () => {
     await page.goto(`#${demandHash('de', 'de')}`);
 
     // Platzhalter ist zunächst auf Deutsch — im Brief und in der URL
-    await expect(page.locator('#letter')).toContainText('TT.MM.JJJJ');
+    await expect(page.locator('[data-qa="letter"]')).toContainText('TT.MM.JJJJ');
     await expect(page).toHaveURL(/TT\.MM\.JJJJ/);
 
     await page.screenshot({ path: screenshotPath(testInfo, '01-platzhalter-deutsch.png'), fullPage: true });
@@ -155,8 +155,8 @@ test.describe('Datumsplatzhalter Übersetzung', () => {
     await page.locator('input[name="correspondence-language"][value="fr"]').click();
 
     // Platzhalter ist nun auf Französisch — im Brief und in der URL
-    await expect(page.locator('#letter')).toContainText('JJ.MM.AAAA');
-    await expect(page.locator('#letter')).not.toContainText('TT.MM.JJJJ');
+    await expect(page.locator('[data-qa="letter"]')).toContainText('JJ.MM.AAAA');
+    await expect(page.locator('[data-qa="letter"]')).not.toContainText('TT.MM.JJJJ');
     await expect(page).toHaveURL(/JJ\.MM\.AAAA/);
     await expect(page).not.toHaveURL(/TT\.MM\.JJJJ/);
 
@@ -165,8 +165,8 @@ test.describe('Datumsplatzhalter Übersetzung', () => {
     // Zurück auf Deutsch wechseln — Platzhalter wird wieder übersetzt
     await page.locator('input[name="correspondence-language"][value="de"]').click();
 
-    await expect(page.locator('#letter')).toContainText('TT.MM.JJJJ');
-    await expect(page.locator('#letter')).not.toContainText('JJ.MM.AAAA');
+    await expect(page.locator('[data-qa="letter"]')).toContainText('TT.MM.JJJJ');
+    await expect(page.locator('[data-qa="letter"]')).not.toContainText('JJ.MM.AAAA');
     await expect(page).toHaveURL(/TT\.MM\.JJJJ/);
     await expect(page).not.toHaveURL(/JJ\.MM\.AAAA/);
   });
@@ -175,7 +175,7 @@ test.describe('Datumsplatzhalter Übersetzung', () => {
     // Echtes Datum direkt über die URL setzen (zuverlässiger als Tippen ins contenteditable)
     await page.goto(`#${demandHash('de', 'de', { dataInfoRequestDate: '15.06.2099' })}`);
 
-    await expect(page.locator('#letter')).toContainText('15.06.2099');
+    await expect(page.locator('[data-qa="letter"]')).toContainText('15.06.2099');
 
     // Korrespondenzsprache auf Französisch umstellen
     await page.locator('[data-qa="language-switch-button"]').click();
@@ -183,7 +183,7 @@ test.describe('Datumsplatzhalter Übersetzung', () => {
 
     // Das echte Datum bleibt unverändert, es wird nicht durch einen Platzhalter ersetzt.
     // (Das noch leere Antwort-Datumsfeld wird hingegen zu JJ.MM.AAAA übersetzt.)
-    await expect(page.locator('#letter')).toContainText('15.06.2099');
+    await expect(page.locator('[data-qa="letter"]')).toContainText('15.06.2099');
     await expect(page).toHaveURL(/15\.06\.2099/);
   });
 
@@ -193,14 +193,14 @@ test.describe('Datumsplatzhalter Übersetzung', () => {
     // und bleibt deshalb unverändert.
     await page.goto(`#${demandHash('de', 'de', { dataInfoRequestDate: '2020-02-20' })}`);
 
-    await expect(page.locator('#letter')).toContainText('2020-02-20');
+    await expect(page.locator('[data-qa="letter"]')).toContainText('2020-02-20');
 
     // Korrespondenzsprache auf Französisch umstellen
     await page.locator('[data-qa="language-switch-button"]').click();
     await page.locator('input[name="correspondence-language"][value="fr"]').click();
 
     // Das ISO-Datum bleibt unverändert (kein Platzhalter-Match → User gewinnt)
-    await expect(page.locator('#letter')).toContainText('2020-02-20');
+    await expect(page.locator('[data-qa="letter"]')).toContainText('2020-02-20');
     await expect(page).toHaveURL(/2020-02-20/);
   });
 });
@@ -213,7 +213,7 @@ test.describe('Editable-Variable Unterstreichung', () => {
     const url = '#{"v":1,"entry":"followup","desire":"unanswered","step":"unanswered","name":"","date":"9.6.2026","dataInfoRequestDate":"TT.MM.JJJJ"}';
     await page.goto(url);
 
-    const span = page.locator('section#letter span.editable-variable[data-label="Datum Begehren"]');
+    const span = page.locator('[data-qa="letter"] span.editable-variable[data-label="Datum Begehren"]');
     await expect(span).toBeVisible();
     await expect(span).toHaveText('TT.MM.JJJJ');
 

--- a/e2e/datenauskunftsbegehren.spec.ts
+++ b/e2e/datenauskunftsbegehren.spec.ts
@@ -5,7 +5,7 @@ test('Der generierte Brief enthält die Daten aus der Url', async ({ page }, tes
   const url = '#{"v":1,"step":"data_info_request","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
   await page.goto(url);
 
-  const letterSection = await page.locator('section#letter');
+  const letterSection = await page.locator('[data-qa="letter"]');
 
   const sectionText = await letterSection.textContent();
 
@@ -108,7 +108,7 @@ test('Datenauskunftsbegehren für Swisscom generieren', async ({ page }, testInf
   // Brief erstellen und Inhalt prüfen
   const generateButton = page.locator('button', { hasText: 'Brief generieren' });
   await generateButton.click();
-  const letterSection = page.locator('section#letter');
+  const letterSection = page.locator('[data-qa="letter"]');
   await expect(letterSection).toContainText('E2E Test');
   await expect(letterSection).toContainText('E2E Strasse');
   await expect(letterSection).toContainText('1000 E2EOrt');
@@ -118,4 +118,38 @@ test('Datenauskunftsbegehren für Swisscom generieren', async ({ page }, testInf
   await expect(letterSection).not.toContainText('Online-Portal');
 
   await page.screenshot({ path: screenshotPath(testInfo, '04-brief-generiert.png'), fullPage: true });
+});
+
+// Regression: Das Ein-/Ausblenden eines einzelnen Bullet-Punkts (z.B. bei Bahnhof Parking AG)
+// löste einen "handler.apply is not a function"- und einen Svelte state_unsafe_mutation-Fehler
+// aus, statt den Punkt für den Druck auszublenden.
+test('Ein einzelner Bullet-Punkt kann aus- und wieder eingeblendet werden', async ({ page }, testInfo) => {
+  const consoleErrors: string[] = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', error => consoleErrors.push(error.message));
+
+  const url = '#{"v":1,"langUi":"de","langCor":"de","org":"Bahnhof Parking AG","entry":"org","types":["parking"],"step":"data_info_request","name":"E2E Person","date":"28.7.2025","address":"E2E Absender"}';
+  await page.goto(url);
+
+  const letterSection = page.locator('[data-qa="letter"]');
+  const firstBullet = letterSection.locator('[data-qa="bullet-item"]').first();
+  await expect(firstBullet).toContainText('Bahnhof Parking Bern');
+
+  const toggleButton = firstBullet.locator('[data-qa="bullet-toggle"]');
+
+  await page.screenshot({ path: screenshotPath(testInfo, '05-bullets-sichtbar.png'), fullPage: true });
+
+  // Bullet ausblenden
+  await toggleButton.click();
+  await expect(firstBullet).toHaveClass(/hide-for-print/);
+
+  await page.screenshot({ path: screenshotPath(testInfo, '06-bullet-ausgeblendet.png'), fullPage: true });
+
+  // Bullet wieder einblenden
+  await toggleButton.click();
+  await expect(firstBullet).not.toHaveClass(/hide-for-print/);
+
+  expect(consoleErrors).toEqual([]);
 });

--- a/e2e/drucken.spec.ts
+++ b/e2e/drucken.spec.ts
@@ -10,7 +10,7 @@ test('Brief Auskunftsbegehren zeigt beim Drucken exakt einen Brief', async ({ pa
   const url = `#{"v":1,"entry":"followup","desire":"data_info_request","step":"print",${baseState}}`;
   await page.goto(url);
 
-  const letterSections = page.locator('section[id="letter"]');
+  const letterSections = page.locator('[data-qa="letter"]');
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).toContainText('Datenauskunftsbegehren');
   await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
@@ -22,7 +22,7 @@ test('Normaler Brief zeigt beim Drucken exakt einen Brief', async ({ page }, tes
   const url = `#{"v":1,"step":"print",${baseState}}`;
   await page.goto(url);
 
-  await expect(page.locator('section[id="letter"]')).toHaveCount(1);
+  await expect(page.locator('[data-qa="letter"]')).toHaveCount(1);
 
   await page.screenshot({ path: screenshotPath(testInfo, '01-druckansicht-normal.png'), fullPage: true });
 });
@@ -31,7 +31,7 @@ test('Nachfassen ausbleibende Auskunft zeigt beim Drucken exakt einen Brief', as
   const url = `#{"v":1,"entry":"followup","desire":"unanswered","step":"print",${baseState}}`;
   await page.goto(url);
 
-  const letterSections = page.locator('section[id="letter"]');
+  const letterSections = page.locator('[data-qa="letter"]');
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).toContainText('Ausbleibende Auskunft');
 
@@ -42,7 +42,7 @@ test('Nachfassen unvollständige Antwort zeigt beim Drucken exakt einen Brief', 
   const url = `#{"v":1,"entry":"followup","desire":"incomplete_answer","step":"print",${baseState}}`;
   await page.goto(url);
 
-  const letterSections = page.locator('section[id="letter"]');
+  const letterSections = page.locator('[data-qa="letter"]');
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
   await expect(letterSections.first()).toContainText('Ich gehe davon aus, dass insbesondere folgende Informationen fehlen');
@@ -54,7 +54,7 @@ test('Nachfassen Daten korrigieren zeigt beim Drucken exakt einen Brief', async 
   const url = `#{"v":1,"entry":"followup","desire":"data_correction","step":"print",${baseState}}`;
   await page.goto(url);
 
-  const letterSections = page.locator('section[id="letter"]');
+  const letterSections = page.locator('[data-qa="letter"]');
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
   await expect(letterSections.first()).toContainText('Aufgrund Ihrer Auskunft stellte ich fest, dass von Ihnen bearbeitete Personendaten unrichtig sind.');
@@ -66,7 +66,7 @@ test('Nachfassen Daten löschen zeigt beim Drucken exakt einen Brief', async ({ 
   const url = `#{"v":1,"entry":"followup","desire":"data_deletion","step":"print",${baseState}}`;
   await page.goto(url);
 
-  const letterSections = page.locator('section[id="letter"]');
+  const letterSections = page.locator('[data-qa="letter"]');
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');
   await expect(letterSections.first()).toContainText('Aufgrund Ihrer Auskunft ersuche ich Sie, folgende Personendaten zu löschen:');
@@ -106,7 +106,7 @@ test('Brief Auskunftsbegehren via Einstiegsmaske zeigt nur einen Brief', async (
   await generateButton.click();
 
   // Nur ein Brief soll sichtbar sein
-  const letterSections = page.locator('section[id="letter"]');
+  const letterSections = page.locator('[data-qa="letter"]');
   await expect(letterSections).toHaveCount(1);
   await expect(letterSections.first()).toContainText('Datenauskunftsbegehren');
   await expect(letterSections.first()).not.toContainText('Ausbleibende Auskunft');

--- a/e2e/ereignis.spec.ts
+++ b/e2e/ereignis.spec.ts
@@ -14,7 +14,7 @@ async function selectEvent(page: Page, eventLabel: string) {
 
 async function generateLetter(page: Page) {
   await page.locator('button', { hasText: 'Brief generieren' }).click();
-  await expect(page.locator('section#letter')).toBeVisible();
+  await expect(page.locator('[data-qa="letter"]')).toBeVisible();
 }
 
 test('Ereignis Werbeanruf: Brief enthält Datum und Telefonnummer', async ({ page }, testInfo) => {
@@ -27,7 +27,7 @@ test('Ereignis Werbeanruf: Brief enthält Datum und Telefonnummer', async ({ pag
 
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Werbeanruf');
   await expect(letter).toContainText('15.03.2024');
   await expect(letter).toContainText('+41 44 123 45 67');
@@ -46,7 +46,7 @@ test('Ereignis Werbemail: Brief enthält Datum und E-Mail-Adresse', async ({ pag
 
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Werbemail');
   await expect(letter).toContainText('20.06.2024');
   await expect(letter).toContainText('test@example.com');
@@ -59,7 +59,7 @@ test('Ereignis Werbung per Post: Datum wird ohne explizite Eingabe im Brief ange
   await selectEvent(page, 'Mir wurde Werbung per Post zugestellt');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter.locator('#eventDate')).not.toHaveText('');
   await expect(letter.locator('#eventDate')).not.toHaveClass(/empty/);
 });
@@ -74,7 +74,7 @@ test('Ereignis Werbung per Post: Brief enthält Datum', async ({ page }, testInf
 
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Werbung per Post');
   await expect(letter).toContainText('10.09.2024');
   await expect(letter).toContainText('E2E Person');
@@ -90,7 +90,7 @@ test('Ereignis Gerücht: Brief enthält den spezifischen Absatz', async ({ page 
 
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Im Zusammenhang mit');
   await expect(letter).toContainText('werden Personendaten bearbeitet');
   await expect(letter).toContainText('E2E Person');

--- a/e2e/geschaeftsbereich.spec.ts
+++ b/e2e/geschaeftsbereich.spec.ts
@@ -14,7 +14,7 @@ async function selectType(page: Page, typeLabel: string) {
 
 async function generateLetter(page: Page) {
   await page.locator('button', { hasText: 'Brief generieren' }).click();
-  await expect(page.locator('section#letter')).toBeVisible();
+  await expect(page.locator('[data-qa="letter"]')).toBeVisible();
 }
 
 test('Geschäftsbereich Adresshandel: Brief enthält spezifischen Absatz', async ({ page }, testInfo) => {
@@ -22,7 +22,7 @@ test('Geschäftsbereich Adresshandel: Brief enthält spezifischen Absatz', async
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Adresshandel');
   await expect(letter).toContainText('Zielgruppen');
   await expect(letter).toContainText('E2E Person');
@@ -35,7 +35,7 @@ test('Geschäftsbereich Kreditauskunft: Brief enthält spezifischen Absatz', asy
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Kreditauskunft');
   await expect(letter).toContainText('Bonitätsprüfung');
   await expect(letter).toContainText('E2E Person');
@@ -48,7 +48,7 @@ test('Geschäftsbereich Gastrodaten: Brief enthält spezifischen Absatz', async 
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Gastronomie');
   await expect(letter).toContainText('Contact Tracing');
   await expect(letter).toContainText('E2E Person');
@@ -61,7 +61,7 @@ test('Geschäftsbereich Kundenkarten-Anbieter: Brief enthält spezifischen Absat
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Kundenkarte');
   await expect(letter).toContainText('E2E Person');
 
@@ -74,7 +74,7 @@ test('Geschäftsbereich Mobilfunkprovider: Brief enthält BÜPF-Absatz und Handy
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Mobilfunk');
   await expect(letter).toContainText('BÜPF');
   await expect(letter).toContainText('+41 79 123 45 67');
@@ -90,7 +90,7 @@ test('Geschäftsbereich Mobilität: Brief enthält Fahrzeug-Absatz und Fahrzeugi
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Mobilität');
   await expect(letter).toContainText('Fahrzeug');
   await expect(letter).toContainText('VW Golf, ZH 123 456');
@@ -105,7 +105,7 @@ test('Geschäftsbereich Online-Portal: Brief enthält E-Mail-Adresse', async ({ 
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('Online-Portal');
   await expect(letter).toContainText('Kundenaktivität');
   await expect(letter).toContainText('test@example.com');
@@ -116,12 +116,13 @@ test('Geschäftsbereich Online-Portal: Brief enthält E-Mail-Adresse', async ({ 
 
 test('Geschäftsbereich Parkplatz-Anbieter: Brief enthält spezifischen Absatz', async ({ page }, testInfo) => {
   await selectType(page, 'Parkplatz-Anbieter');
+  await page.getByLabel('Kontrollschild').fill('BE 123 456');
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
-  await expect(letter).toContainText('parkingprovider');
-  await expect(letter).toContainText('Parkieren');
+  const letter = page.locator('[data-qa="letter"]');
+  await expect(letter).toContainText('Parkplatz');
+  await expect(letter).toContainText('BE 123 456');
   await expect(letter).toContainText('E2E Person');
 
   await page.screenshot({ path: screenshotPath(testInfo, '01-brief-parkplatz.png'), fullPage: true });
@@ -133,7 +134,7 @@ test('Geschäftsbereich WLAN-Anbieter: Brief enthält BÜPF-Absatz und Handy-Num
   await fillUserAddress(page, 'E2E Person', 'E2E Strasse\n1000 E2EOrt');
   await generateLetter(page);
 
-  const letter = page.locator('section#letter');
+  const letter = page.locator('[data-qa="letter"]');
   await expect(letter).toContainText('WLAN');
   await expect(letter).toContainText('BÜPF');
   await expect(letter).toContainText('+41 79 987 65 43');

--- a/e2e/language.spec.ts
+++ b/e2e/language.spec.ts
@@ -133,8 +133,8 @@ test('UI Deutsch, Korrespondenzsprache Französisch: Seite auf Deutsch, Brief au
   await expect(page.locator('button.no-print').first()).toHaveText('❮ zur Dateneingabe');
 
   // Briefinhalt ist Französisch
-  await expect(page.locator('#letter .salutation')).toContainText(letterSnippets.fr.salutation);
-  await expect(page.locator('#letter .address-to')).toContainText(letterSnippets.fr.registeredMail);
+  await expect(page.locator('[data-qa="letter"] .salutation')).toContainText(letterSnippets.fr.salutation);
+  await expect(page.locator('[data-qa="letter"] .address-to')).toContainText(letterSnippets.fr.registeredMail);
 
   await page.screenshot({ path: screenshotPath(testInfo, '01-ui-de-brief-fr.png'), fullPage: true });
 });
@@ -146,8 +146,8 @@ test('UI Französisch, Korrespondenzsprache Deutsch: Seite auf Französisch, Bri
   await expect(page.locator('button.no-print').first()).toHaveText('❮ à la saisie');
 
   // Briefinhalt ist Deutsch
-  await expect(page.locator('#letter .salutation')).toContainText(letterSnippets.de.salutation);
-  await expect(page.locator('#letter .address-to')).toContainText(letterSnippets.de.registeredMail);
+  await expect(page.locator('[data-qa="letter"] .salutation')).toContainText(letterSnippets.de.salutation);
+  await expect(page.locator('[data-qa="letter"] .address-to')).toContainText(letterSnippets.de.registeredMail);
 
   await page.screenshot({ path: screenshotPath(testInfo, '01-ui-fr-brief-de.png'), fullPage: true });
 });

--- a/e2e/nachfassen.spec.ts
+++ b/e2e/nachfassen.spec.ts
@@ -28,7 +28,7 @@ test('Nachfassen bei ausbleibender Antwort', async ({ page }, testInfo) => {
   await keineAntwortButton.click();
 
   // Prüfen, dass es sich um die Vorlage ausbleibende Auskunft handelt
-  const letterSection = await page.locator('section#letter');
+  const letterSection = await page.locator('[data-qa="letter"]');
   const sectionText = await letterSection.textContent();
   expect(sectionText).toContain('Datenauskunftsbegehren / Ausbleibende Auskunft');
   expect(sectionText).toContain('E2E Person');
@@ -45,7 +45,7 @@ test('Nachfassen bei ausbleibender Antwort mit Datum im URL', async ({ page }) =
   const url = '#{"v":1,"step":"unanswered","entry":"followup","desire":"unanswered","name":"E2E Person","date":"28.7.2025","dataInfoRequestDate":"15.1.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
   await page.goto(url);
 
-  const letterSection = await page.locator('section#letter');
+  const letterSection = await page.locator('[data-qa="letter"]');
   const sectionText = await letterSection.textContent();
   expect(sectionText).toContain('15.1.2025');
 });
@@ -60,7 +60,7 @@ test('Nachfassen unvollständige Antwort', async ({ page }, testInfo) => {
   await keineAntwortButton.click();
 
   // Prüfen, dass es sich um die Vorlage unvollständige Antwort handelt
-  const letterSection = await page.locator('section#letter');
+  const letterSection = await page.locator('[data-qa="letter"]');
   const sectionText = await letterSection.textContent();
   expect(sectionText).toContain('Ich gehe davon aus, dass insbesondere folgende Informationen fehlen');
   expect(sectionText).toContain('E2E Person');
@@ -83,7 +83,7 @@ test('Nachfassen Daten korrigieren lassen', async ({ page }, testInfo) => {
   await keineAntwortButton.click();
 
   // Prüfen, dass es sich um die Vorlage Daten korrigieren handelt
-  const letterSection = await page.locator('section#letter');
+  const letterSection = await page.locator('[data-qa="letter"]');
   const sectionText = await letterSection.textContent();
   expect(sectionText).toContain('Aufgrund Ihrer Auskunft stellte ich fest, dass von Ihnen bearbeitete Personendaten unrichtig sind.');
   expect(sectionText).toContain('E2E Person');
@@ -106,7 +106,7 @@ test('Nachfassen Daten löschen lassen', async ({ page }, testInfo) => {
   await keineAntwortButton.click();
 
   // Prüfen, dass es sich um die Vorlage Daten löschen handelt
-  const letterSection = await page.locator('section#letter');
+  const letterSection = await page.locator('[data-qa="letter"]');
   const sectionText = await letterSection.textContent();
   expect(sectionText).toContain('Aufgrund Ihrer Auskunft ersuche ich Sie, folgende Personendaten zu löschen:');
   expect(sectionText).toContain('E2E Person');
@@ -133,7 +133,7 @@ test('Nachfassen bietet Datenaushändigung nicht mehr an', async ({ page }) => {
   // Direkter URL-Aufruf mit desire=data_handover darf keinen Brief erzeugen
   const url = '#{"v":1,"step":"data_handover","entry":"followup","desire":"data_handover","name":"E2E Person","date":"28.7.2025","dataInfoResponseDate":"3.3.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
   await page.goto(url);
-  await expect(page.locator('section#letter')).toHaveCount(0);
+  await expect(page.locator('[data-qa="letter"]')).toHaveCount(0);
 });
 
 test('Vorausgewählte Organisation aus URL wird in der Auswahl angezeigt', async ({ page }, testInfo) => {

--- a/src/letter/Bullets.svelte
+++ b/src/letter/Bullets.svelte
@@ -88,10 +88,10 @@
 <ul>
   {#if bullets}
     {#each bullets as bullet}
-      <li class:hide-for-print={$userData.hiddenBullets && $userData.hiddenBullets.includes(bullet.hash)}>
+      <li data-qa="bullet-item" class:hide-for-print={$userData.hiddenBullets && $userData.hiddenBullets.includes(bullet.hash)}>
         {bullet.text}
         <Bullets bullets={bullet.bullets} on:toggle={handleToggle} isChild={true}></Bullets>
-         <HideNodeAction on:toggle={handleToggle({detail: bullet.hash})} setClass={false} 
+         <HideNodeAction on:toggle={() => handleToggle({detail: bullet.hash})} setClass={false} dataQa="bullet-toggle"
          title={$_("bullets.toggle_visibility", {default: "Ein-/ausblenden, damit nur die Daten angefordert werden, die auch bearbeitet werden und von Interesse sind."})}></HideNodeAction>
       </li>
     {/each}

--- a/src/letter/HideNodeAction.svelte
+++ b/src/letter/HideNodeAction.svelte
@@ -10,10 +10,11 @@
    * @typedef {Object} Props
    * @property {string} [title]
    * @property {boolean} [setClass]
+   * @property {string} [dataQa]
    */
 
   /** @type {Props} */
-  let { title = "", setClass = true } = $props();
+  let { title = "", setClass = true, dataQa = "hide-node-action" } = $props();
 
   function toggleNode() {
     if (setClass) {
@@ -29,7 +30,7 @@
   })
   
 </script>
-<button type="button" class="hide-node-action" bind:this={node} onclick={toggleNode} title="{title}">
+<button type="button" class="hide-node-action" data-qa={dataQa} bind:this={node} onclick={toggleNode} title="{title}">
   <EyeIcon></EyeIcon>
 </button>
 <style>

--- a/src/letter/LetterDataInfoReq.svelte
+++ b/src/letter/LetterDataInfoReq.svelte
@@ -80,7 +80,7 @@
 </script>
 
 <div id="letter-container">
-  <section id="letter" bind:this={letterDataInfoReqNode}>
+  <section id="letter" data-qa="letter" bind:this={letterDataInfoReqNode}>
     <div class="letter-head">
       <div class="address-from">
          <span

--- a/src/letter/LetterDataInfoReqChange.svelte
+++ b/src/letter/LetterDataInfoReqChange.svelte
@@ -60,7 +60,7 @@
 </script>
 
 <div id="letter-container">
-  <section id="letter" bind:this={LetterDataInfoReqChangeNode}>
+  <section id="letter" data-qa="letter" bind:this={LetterDataInfoReqChangeNode}>
     <div class="letter-head">
       <div class="address-from">
         <span

--- a/src/letter/LetterDataInfoReqDelete.svelte
+++ b/src/letter/LetterDataInfoReqDelete.svelte
@@ -59,7 +59,7 @@
 </script>
 
 <div id="letter-container">
-  <section id="letter" bind:this={LetterDataInfoReqDeleteNode}>
+  <section id="letter" data-qa="letter" bind:this={LetterDataInfoReqDeleteNode}>
     <div class="letter-head">
       <div class="address-from">
          <span

--- a/src/letter/LetterDataInfoReqDemand.svelte
+++ b/src/letter/LetterDataInfoReqDemand.svelte
@@ -64,7 +64,7 @@
 </script>
 
 <div id="letter-container">
-  <section id="letter" bind:this={LetterDataInfoReqDemandNode}>
+  <section id="letter" data-qa="letter" bind:this={LetterDataInfoReqDemandNode}>
     <div class="letter-head">
       <div class="address-from">
          <span

--- a/src/letter/LetterDataInfoReqRemind.svelte
+++ b/src/letter/LetterDataInfoReqRemind.svelte
@@ -61,7 +61,7 @@
 </script>
 
 <div id="letter-container">
-  <section id="letter" bind:this={LetterDataInfoReqRemindNode}>
+  <section id="letter" data-qa="letter" bind:this={LetterDataInfoReqRemindNode}>
     <div class="letter-head">
       <div class="address-from">
          <span


### PR DESCRIPTION
The `on:toggle` handler on `HideNodeAction` in Bullets.svelte was invoked immediately during render instead of being passed as a callback, causing a `state_unsafe_mutation` error on render and a `handler.apply is not a function` error once clicked, instead of toggling the bullet's visibility for print.

- Wrap the handler call in an arrow function so it fires on click.
- Add `data-qa` attributes to bullets, the toggle button, and the letter section, and switch e2e locators to them instead of text/CSS-id selectors for more robust tests.
- Add a regression test for the bullet toggle.
- Fix the pre-existing "Parkplatz-Anbieter" e2e test, which had drifted from the current org data (asserted on stale "parkingprovider"/ "Parkieren" text and never filled the required Kontrollschild field).