### PR TITLE
fix(letter): don't imply Art. 25 DSG is the only legal basis for the …

### DIFF
--- a/e2e/datenauskunftsbegehren.spec.ts
+++ b/e2e/datenauskunftsbegehren.spec.ts
@@ -15,6 +15,11 @@ test('Der generierte Brief enthält die Daten aus der Url', async ({ page }, tes
   expect(sectionText).toContain('E2E Empfänger');
   expect(sectionText).toContain('28.7.2025');
 
+  // Regression: Die Rechtsgrundlage darf nicht als abschliessend formuliert sein,
+  // damit auch Anspruchsgrundlagen jenseits von Art. 25 DSG offenbleiben (#194)
+  expect(sectionText).toContain('insbesondere mit Verweis auf Art. 25');
+  expect(sectionText).toContain('insbesondere gemäss DSG');
+
   await page.screenshot({ path: screenshotPath(testInfo, '01-brief-aus-url.png'), fullPage: true });
 });
 

--- a/src/locales/de-CH.letter.json
+++ b/src/locales/de-CH.letter.json
@@ -11,8 +11,8 @@
   "data_info_request": "Datenauskunftsbegehren",
   "salutation": "Sehr geehrte Angesprochene",
   "letter": {
-    "initial_request": "Ich ersuche Sie mit Verweis auf Art. 25 des Bundesgesetzes über den Datenschutz (DSG) vom 25. September 2020, mir innerhalb von 30 Tagen mitzuteilen, ob Daten über mich bearbeitet werden.",
-    "info_requirement": "Sofern Daten über mich bearbeitet werden, ersuche ich Sie weiter, mir diejenigen Informationen mitzuteilen, die erforderlich sind, damit ich meine Rechte gemäss DSG geltend machen kann und eine transparente Bearbeitung meiner Daten gewährleistet ist.",
+    "initial_request": "Ich ersuche Sie, insbesondere mit Verweis auf Art. 25 des Bundesgesetzes über den Datenschutz (DSG) vom 25. September 2020, mir innerhalb von 30 Tagen mitzuteilen, ob Daten über mich bearbeitet werden.",
+    "info_requirement": "Sofern Daten über mich bearbeitet werden, ersuche ich Sie weiter, mir diejenigen Informationen mitzuteilen, die erforderlich sind, damit ich meine Rechte insbesondere gemäss DSG geltend machen kann und eine transparente Bearbeitung meiner Daten gewährleistet ist.",
     "request_info_list": "Ich ersuche Sie in diesem Rahmen, mir in jedem Fall folgende Informationen mitzuteilen:",
     "list_item_1": "Identität und Kontaktdaten aller Verantwortlichen",
     "list_item_2": "Alle bearbeiteten Personendaten als solche",

--- a/src/locales/fr-CH.letter.json
+++ b/src/locales/fr-CH.letter.json
@@ -11,8 +11,8 @@
   "data_info_request": "Requête de données traitées",
   "salutation": "Chère Madame, cher Monsieur,",
   "letter": {
-    "initial_request": "Je vous prie de m'indiquer dans un délai de 30 jours si des données me concernant on fait l'objet d'un traitement. Cette demande est fondée sur l'art. 25 de la Loi fédérale sur la protection des données (LPD) du 25 septembre 2020.",
-    "info_requirement": "Dans la mesure où des données me concernant ont fait l'objet d'un traitement, je vous prie de me communiquer les informations pertinentes pour me permettre d'exercer mes droits selon la LPD et pour garantir la transparence dans le traitement de mes données.",
+    "initial_request": "Je vous prie de m'indiquer dans un délai de 30 jours si des données me concernant ont fait l'objet d'un traitement. Cette demande est fondée notamment sur l'art. 25 de la Loi fédérale sur la protection des données (LPD) du 25 septembre 2020.",
+    "info_requirement": "Dans la mesure où des données me concernant ont fait l'objet d'un traitement, je vous prie de me communiquer les informations pertinentes pour me permettre d'exercer mes droits, notamment selon la LPD, et pour garantir la transparence dans le traitement de mes données.",
     "request_info_list": "Je vous sollicite dans ce cadre de me transmettre les informations suivantes:",
     "list_item_1": "L'identité et les données de contact de tous les responsables",
     "list_item_2": "Les données à l'état brut qui ont été traitées",


### PR DESCRIPTION
…request

Add "insbesondere" / "notamment" to the initial data-access-request letter so the cited legal basis (Art. 25 DSG) and legal grounds for exercising one's rights are non-exhaustive, leaving room for other applicable claims. Also fixes a grammar typo in the French letter ("on fait" -> "ont fait").

Closes #194