### PR TITLE
fix(letter): keep legal citations unbroken and give each follow-up it…

### DIFF
--- a/e2e/datenauskunftsbegehren.spec.ts
+++ b/e2e/datenauskunftsbegehren.spec.ts
@@ -18,6 +18,23 @@ test('Der generierte Brief enthält die Daten aus der Url', async ({ page }, tes
   await page.screenshot({ path: screenshotPath(testInfo, '01-brief-aus-url.png'), fullPage: true });
 });
 
+// Rechtsverweise und Datumsangaben dürfen nicht umbrechen: Abkürzung, Nummer
+// bzw. Tag, Monat und Jahr sind mit geschützten Leerzeichen (U+00A0) verbunden.
+const NBSP = '\u00A0';
+
+test('Rechtsverweise und Datum bleiben dank geschützter Leerzeichen am Stück', async ({ page }) => {
+  const url = '#{"v":1,"step":"data_info_request","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}';
+  await page.goto(url);
+
+  const letterText = await page.locator('[data-qa="letter"]').textContent();
+
+  expect(letterText).toContain(`25.${NBSP}September${NBSP}2020`);
+  expect(letterText).not.toContain('25. September 2020');
+
+  expect(letterText).toContain(`Art.${NBSP}25 des Bundesgesetzes`);
+  expect(letterText).not.toContain('Art. 25 des Bundesgesetzes');
+});
+
 test('Eine entfernte und wieder hinzugefügte Organisation ist auswählbar', async ({ page }, testInfo) => {
   // Eine Test-Organisation einschleusen, deren jüngstes History-Ereignis ein
   // "added" nach einem früheren "removed" ist. Massgeblich für den aktuellen

--- a/e2e/language.spec.ts
+++ b/e2e/language.spec.ts
@@ -136,6 +136,15 @@ test('UI Deutsch, Korrespondenzsprache Französisch: Seite auf Deutsch, Brief au
   await expect(page.locator('[data-qa="letter"] .salutation')).toContainText(letterSnippets.fr.salutation);
   await expect(page.locator('[data-qa="letter"] .address-to')).toContainText(letterSnippets.fr.registeredMail);
 
+  // Rechtsverweise und Datum dürfen nicht umbrechen: Abkürzung, Nummer bzw.
+  // Tag, Monat und Jahr sind mit geschützten Leerzeichen (U+00A0) verbunden.
+  const NBSP = '\u00A0';
+  const letterText = await page.locator('[data-qa="letter"]').textContent();
+  expect(letterText).toContain(`25${NBSP}septembre${NBSP}2020`);
+  expect(letterText).not.toContain('25 septembre 2020');
+  expect(letterText).toContain(`art.${NBSP}25 de la Loi`);
+  expect(letterText).not.toContain('art. 25 de la Loi');
+
   await page.screenshot({ path: screenshotPath(testInfo, '01-ui-de-brief-fr.png'), fullPage: true });
 });
 

--- a/e2e/nachfassen.spec.ts
+++ b/e2e/nachfassen.spec.ts
@@ -62,6 +62,7 @@ test('Nachfassen unvollständige Antwort', async ({ page }, testInfo) => {
   // Prüfen, dass es sich um die Vorlage unvollständige Antwort handelt
   const letterSection = await page.locator('[data-qa="letter"]');
   const sectionText = await letterSection.textContent();
+  expect(sectionText).toContain('Datenauskunftsbegehren / Unvollständige Auskunft');
   expect(sectionText).toContain('Ich gehe davon aus, dass insbesondere folgende Informationen fehlen');
   expect(sectionText).toContain('E2E Person');
   expect(sectionText).toContain('E2E Absender');
@@ -71,6 +72,29 @@ test('Nachfassen unvollständige Antwort', async ({ page }, testInfo) => {
   await page.screenshot({ path: screenshotPath(testInfo, '01-brief-unvollstaendige-antwort.png'), fullPage: true });
   // Beide Datums-Platzhalter (Begehren + Antwort) müssen erscheinen
   expect(sectionText?.match(/TT\.MM\.JJJJ/g)?.length).toBeGreaterThanOrEqual(2);
+});
+
+// Rechtsverweise und Datumsangaben dürfen nicht umbrechen: Abkürzung, Nummer
+// bzw. Tag, Monat und Jahr sind mit geschützten Leerzeichen (U+00A0) verbunden.
+const NBSP = '\u00A0';
+
+test('Rechtsverweise und Datum bleiben dank geschützter Leerzeichen am Stück', async ({ page }) => {
+  const followUpUrl = (desire: string) =>
+    `#{"v":1,"step":"${desire}","entry":"followup","desire":"${desire}","name":"E2E Person","date":"28.7.2025","orgAddressEntry":"E2E Empfänger","address":"E2E Absender"}`;
+
+  for (const desire of ['unanswered', 'incomplete_answer']) {
+    await page.goto(followUpUrl(desire));
+    const letterText = await page.locator('[data-qa="letter"]').textContent();
+
+    expect(letterText).toContain(`31.${NBSP}August${NBSP}2022`);
+    expect(letterText).not.toContain('31. August 2022');
+
+    expect(letterText).toContain(`Art.${NBSP}18 der Verordnung`);
+    expect(letterText).not.toContain('Art. 18 der Verordnung');
+
+    expect(letterText).toContain(`Art.${NBSP}60${NBSP}DSG`);
+    expect(letterText).not.toContain('Art. 60 DSG');
+  }
 });
 
 test('Nachfassen Daten korrigieren lassen', async ({ page }, testInfo) => {
@@ -85,6 +109,7 @@ test('Nachfassen Daten korrigieren lassen', async ({ page }, testInfo) => {
   // Prüfen, dass es sich um die Vorlage Daten korrigieren handelt
   const letterSection = await page.locator('[data-qa="letter"]');
   const sectionText = await letterSection.textContent();
+  expect(sectionText).toContain('Datenauskunftsbegehren / Berichtigung');
   expect(sectionText).toContain('Aufgrund Ihrer Auskunft stellte ich fest, dass von Ihnen bearbeitete Personendaten unrichtig sind.');
   expect(sectionText).toContain('E2E Person');
   expect(sectionText).toContain('E2E Absender');
@@ -108,6 +133,7 @@ test('Nachfassen Daten löschen lassen', async ({ page }, testInfo) => {
   // Prüfen, dass es sich um die Vorlage Daten löschen handelt
   const letterSection = await page.locator('[data-qa="letter"]');
   const sectionText = await letterSection.textContent();
+  expect(sectionText).toContain('Datenauskunftsbegehren / Löschung');
   expect(sectionText).toContain('Aufgrund Ihrer Auskunft ersuche ich Sie, folgende Personendaten zu löschen:');
   expect(sectionText).toContain('E2E Person');
   expect(sectionText).toContain('E2E Absender');

--- a/src/letter/LetterDataInfoReq.svelte
+++ b/src/letter/LetterDataInfoReq.svelte
@@ -157,7 +157,7 @@
     {/if}
 
     <p contenteditable spellcheck="false">
-      {$_("letter.initial_request", {default: "Ich ersuche Sie mit Verweis auf Art. 25 des Bundesgesetzes über den Datenschutz (DSG) vom 25.\u00A0September 2020, mir innerhalb von 30 Tagen mitzuteilen, ob Daten über mich bearbeitet werden."})}
+      {$_("letter.initial_request", {default: "Ich ersuche Sie mit Verweis auf Art.\u00A025 des Bundesgesetzes über den Datenschutz (DSG) vom 25.\u00A0September\u00A02020, mir innerhalb von 30 Tagen mitzuteilen, ob Daten über mich bearbeitet werden."})}
     </p>
     <p>
       {$_("letter.info_requirement", {default: "Sofern Daten über mich bearbeitet werden, ersuche ich Sie weiter, mir diejenigen Informationen mitzuteilen, die erforderlich sind, damit ich meine Rechte gemäss DSG geltend machen kann und eine transparente Bearbeitung meiner Daten gewährleistet ist."})}

--- a/src/letter/LetterDataInfoReqChange.svelte
+++ b/src/letter/LetterDataInfoReqChange.svelte
@@ -115,7 +115,7 @@
     </div>
 
     <h1 class="subject" contenteditable spellcheck="false">
-       {$_("data_access_request", {default: "Datenauskunftsbegehren"})}
+       {$_("letter_info_req_change_subject", {default: "Datenauskunftsbegehren / Berichtigung"})}
      </h1>
 
      <p class="salutation" contenteditable spellcheck="false">

--- a/src/letter/LetterDataInfoReqDelete.svelte
+++ b/src/letter/LetterDataInfoReqDelete.svelte
@@ -114,7 +114,7 @@
     </div>
 
     <h1 class="subject" contenteditable spellcheck="false">
-      {$_("data_disclosure_request", { default: "Datenauskunftsbegehren" })}
+      {$_("letter_info_req_delete_subject", { default: "Datenauskunftsbegehren / Löschung" })}
     </h1>
 
     <p class="salutation" contenteditable spellcheck="false">

--- a/src/letter/LetterDataInfoReqDemand.svelte
+++ b/src/letter/LetterDataInfoReqDemand.svelte
@@ -119,7 +119,7 @@
     </div>
 
     <h1 class="subject" contenteditable spellcheck="false">
-      {$_("data_info_request")}
+      {$_("letter_info_req_demand_subject", { default: "Datenauskunftsbegehren / Unvollständige Auskunft" })}
     </h1>
 
     <p class="salutation" contenteditable spellcheck="false">
@@ -147,10 +147,10 @@
        <li contenteditable spellcheck="false">...</li>
      </ul>
     <p contenteditable spellcheck="false">
-      {$_("letter_info_req_demand_refusal", {default: "Gemäss Art. 18 der Verordnung über den Datenschutz (Datenschutzverordnung, DSV) vom 31. August 2022 müssen Angaben geliefert werden, wieso eine Auskunft eingeschränkt wurde. Ich bitte Sie entsprechend, vollständig Auskunft zu erteilen oder Angaben zu liefern, wieso die Auskunft eingeschränkt wurde.."})}
+      {$_("letter_info_req_demand_refusal", {default: "Gemäss Art.\u00A018 der Verordnung über den Datenschutz (Datenschutzverordnung, DSV) vom 31.\u00A0August\u00A02022 müssen Angaben geliefert werden, wieso eine Auskunft eingeschränkt wurde. Ich bitte Sie entsprechend, vollständig Auskunft zu erteilen oder Angaben zu liefern, wieso die Auskunft eingeschränkt wurde.."})}
     </p>
     <p contenteditable spellcheck="false">
-      {$_("letter_info_req_demand_enforcement", {default: "Sollten Sie weiterhin keine vollständige Auskunft erteilen, behalte ich mir jederzeit vor, mein Auskunftsrecht auf dem Rechtsweg durchzusetzen oder Anzeige beim Eidgenössischen Datenschutz- und Öffentlichkeitsbeauftragten (EDÖB) zu erstatten. Ich weise ausserdem darauf hin, dass das vorsätzliche Erteilen einer falschen oder unvollständigen Auskunft auf Antrag mit Busse bis zu 250'000 Franken bestraft werden kann (Art. 60 DSG)."})}
+      {$_("letter_info_req_demand_enforcement", {default: "Sollten Sie weiterhin keine vollständige Auskunft erteilen, behalte ich mir jederzeit vor, mein Auskunftsrecht auf dem Rechtsweg durchzusetzen oder Anzeige beim Eidgenössischen Datenschutz- und Öffentlichkeitsbeauftragten (EDÖB) zu erstatten. Ich weise ausserdem darauf hin, dass das vorsätzliche Erteilen einer falschen oder unvollständigen Auskunft auf Antrag mit Busse bis zu 250'000 Franken bestraft werden kann (Art.\u00A060\u00A0DSG)."})}
     </p>
 
      <div class="no-break-inside">

--- a/src/letter/LetterDataInfoReqRemind.svelte
+++ b/src/letter/LetterDataInfoReqRemind.svelte
@@ -131,10 +131,10 @@
         class:empty={!$userData.dataInfoRequestDate || $userData.dataInfoRequestDate.length === 0}
         bind:innerHTML={$userData.dataInfoRequestDate}></span>{$_("letter_info_req_remind.unanswered_request_post", { default: " stellte ich ein Datenauskunftsbegehren, das bis heute unbeantwortet geblieben ist." })}</p>
     <p contenteditable spellcheck="false">
-      {$_("letter_info_req_remind.legal_reference", { default: "Gemäss Art. 18 der Verordnung über den Datenschutz (Datenschutzverordnung, DSV) vom 31. August 2022 müssen die Auskunft oder die Information über eine verzögerte Auskunft innerhalb von 30 Tagen erfolgen. Ebenfalls innerhalb von 30 Tagen muss mitgeteilt werden, wenn die Auskunft verweigert oder aufgeschoben wird." })}
+      {$_("letter_info_req_remind.legal_reference", { default: "Gemäss Art.\u00A018 der Verordnung über den Datenschutz (Datenschutzverordnung, DSV) vom 31.\u00A0August\u00A02022 müssen die Auskunft oder die Information über eine verzögerte Auskunft innerhalb von 30 Tagen erfolgen. Ebenfalls innerhalb von 30 Tagen muss mitgeteilt werden, wenn die Auskunft verweigert oder aufgeschoben wird." })}
     </p>
     <p contenteditable spellcheck="false">
-      {$_("letter_info_req_remind.enforcement", { default: "Ich bitte Sie entsprechend, die Auskunft zu erteilen. Sollten Sie weiterhin keine Auskunft erteilen, behalte ich mir jederzeit vor, mein Auskunftsrecht auf dem Rechtsweg durchzusetzen oder Anzeige beim Eidgenössischen Datenschutz- und Öffentlichkeitsbeauftragten (EDÖB) zu erstatten.  Ich weise ausserdem vorsorglich darauf hin, dass das vorsätzliche Erteilen einer falschen oder unvollständigen Auskunft auf Antrag mit Busse bis zu 250'000 Franken bestraft werden kann (Art. 60 DSG)." })}
+      {$_("letter_info_req_remind.enforcement", { default: "Ich bitte Sie entsprechend, die Auskunft zu erteilen. Sollten Sie weiterhin keine Auskunft erteilen, behalte ich mir jederzeit vor, mein Auskunftsrecht auf dem Rechtsweg durchzusetzen oder Anzeige beim Eidgenössischen Datenschutz- und Öffentlichkeitsbeauftragten (EDÖB) zu erstatten.  Ich weise ausserdem vorsorglich darauf hin, dass das vorsätzliche Erteilen einer falschen oder unvollständigen Auskunft auf Antrag mit Busse bis zu 250'000 Franken bestraft werden kann (Art.\u00A060\u00A0DSG)." })}
     </p>
 
     <div class="no-break-inside">

--- a/src/locales/de-CH.letter.json
+++ b/src/locales/de-CH.letter.json
@@ -11,7 +11,7 @@
   "data_info_request": "Datenauskunftsbegehren",
   "salutation": "Sehr geehrte Angesprochene",
   "letter": {
-    "initial_request": "Ich ersuche Sie mit Verweis auf Art. 25 des Bundesgesetzes über den Datenschutz (DSG) vom 25. September 2020, mir innerhalb von 30 Tagen mitzuteilen, ob Daten über mich bearbeitet werden.",
+    "initial_request": "Ich ersuche Sie mit Verweis auf Art. 25 des Bundesgesetzes über den Datenschutz (DSG) vom 25. September 2020, mir innerhalb von 30 Tagen mitzuteilen, ob Daten über mich bearbeitet werden.",
     "info_requirement": "Sofern Daten über mich bearbeitet werden, ersuche ich Sie weiter, mir diejenigen Informationen mitzuteilen, die erforderlich sind, damit ich meine Rechte gemäss DSG geltend machen kann und eine transparente Bearbeitung meiner Daten gewährleistet ist.",
     "request_info_list": "Ich ersuche Sie in diesem Rahmen, mir in jedem Fall folgende Informationen mitzuteilen:",
     "list_item_1": "Identität und Kontaktdaten aller Verantwortlichen",
@@ -28,7 +28,7 @@
   },
   "closing": "Besten Dank und freundliche Grüsse",
   "attachment_official_id": "Beilage: Amtlicher Ausweis (Kopie)",
-  "data_access_request": "Datenauskunftsbegehren",
+  "letter_info_req_change_subject": "Datenauskunftsbegehren / Berichtigung",
   "thank_you_message_pre": "Ich danke Ihnen für die Auskunft vom ",
   "thank_you_message_post": ".",
   "letter_change_body_1_continuation": "Aufgrund Ihrer Auskunft stellte ich fest, dass von Ihnen bearbeitete Personendaten unrichtig sind.",
@@ -36,7 +36,7 @@
   "letter_change_list_item": "[Auflistung der zu berichtigenden Daten und gewünschte Berichtigung]",
   "letter_change_body_3": "Ich verlange ferner, dass Sie die Berichtigung Dritten, von welchen Sie die unrichtigen Daten erhalten oder denen Sie die unrichtigen Daten weitergegeben haben, entsprechend informieren.",
   "letter_change_body_4": "Ich bitte Sie schliesslich, die Berichtigung zu bestätigen.",
-  "data_disclosure_request": "Datenauskunftsbegehren",
+  "letter_info_req_delete_subject": "Datenauskunftsbegehren / Löschung",
   "deletion_request_message": "Aufgrund Ihrer Auskunft ersuche ich Sie, folgende Personendaten zu löschen:",
   "deletion_list_placeholder": "[Auflistung der zu löschenden Daten oder sämtliche Daten]",
   "inform_third_parties_message": "Ich verlange ferner, dass Sie die Löschung Dritten, von welchen Sie die zu löschenden Daten erhalten oder denen Sie die zu löschenden Daten weitergegeben haben, entsprechend informieren.",
@@ -46,13 +46,14 @@
   "letter_info_req_demand_incomplete_post": " nicht vollständig beantwortet.",
   "letter_info_req_demand_missing_info": "Ich gehe davon aus, dass insbesondere folgende Informationen fehlen:",
   "letter_info_req_demand_list_missing": "[Auflistung der fehlenden Daten]",
-  "letter_info_req_demand_refusal": "Gemäss Art. 18 der Verordnung über den Datenschutz (Datenschutzverordnung, DSV) vom 31. August 2022 müssen Angaben geliefert werden, wieso eine Auskunft eingeschränkt wurde. Ich bitte Sie entsprechend, vollständig Auskunft zu erteilen oder Angaben zu liefern, wieso die Auskunft eingeschränkt wurde..",
-  "letter_info_req_demand_enforcement": "Sollten Sie weiterhin keine vollständige Auskunft erteilen, behalte ich mir jederzeit vor, mein Auskunftsrecht auf dem Rechtsweg durchzusetzen oder Anzeige beim Eidgenössischen Datenschutz- und Öffentlichkeitsbeauftragten (EDÖB) zu erstatten. Ich weise ausserdem darauf hin, dass das vorsätzliche Erteilen einer falschen oder unvollständigen Auskunft auf Antrag mit Busse bis zu 250'000 Franken bestraft werden kann (Art. 60 DSG).",
+  "letter_info_req_demand_subject": "Datenauskunftsbegehren / Unvollständige Auskunft",
+  "letter_info_req_demand_refusal": "Gemäss Art. 18 der Verordnung über den Datenschutz (Datenschutzverordnung, DSV) vom 31. August 2022 müssen Angaben geliefert werden, wieso eine Auskunft eingeschränkt wurde. Ich bitte Sie entsprechend, vollständig Auskunft zu erteilen oder Angaben zu liefern, wieso die Auskunft eingeschränkt wurde..",
+  "letter_info_req_demand_enforcement": "Sollten Sie weiterhin keine vollständige Auskunft erteilen, behalte ich mir jederzeit vor, mein Auskunftsrecht auf dem Rechtsweg durchzusetzen oder Anzeige beim Eidgenössischen Datenschutz- und Öffentlichkeitsbeauftragten (EDÖB) zu erstatten. Ich weise ausserdem darauf hin, dass das vorsätzliche Erteilen einer falschen oder unvollständigen Auskunft auf Antrag mit Busse bis zu 250'000 Franken bestraft werden kann (Art. 60 DSG).",
   "letter_info_req_remind": {
     "subject": "Datenauskunftsbegehren / Ausbleibende Auskunft",
     "unanswered_request_pre": "Am ",
     "unanswered_request_post": " stellte ich ein Datenauskunftsbegehren, das bis heute unbeantwortet geblieben ist.",
-    "legal_reference": "Gemäss Art. 18 der Verordnung über den Datenschutz (Datenschutzverordnung, DSV) vom 31. August 2022 müssen die Auskunft oder die Information über eine verzögerte Auskunft innerhalb von 30 Tagen erfolgen. Ebenfalls innerhalb von 30 Tagen muss mitgeteilt werden, wenn die Auskunft verweigert oder aufgeschoben wird.",
-    "enforcement": "Ich bitte Sie entsprechend, die Auskunft zu erteilen. Sollten Sie weiterhin keine Auskunft erteilen, behalte ich mir jederzeit vor, mein Auskunftsrecht auf dem Rechtsweg durchzusetzen oder Anzeige beim Eidgenössischen Datenschutz- und Öffentlichkeitsbeauftragten (EDÖB) zu erstatten.  Ich weise ausserdem vorsorglich darauf hin, dass das vorsätzliche Erteilen einer falschen oder unvollständigen Auskunft auf Antrag mit Busse bis zu 250'000 Franken bestraft werden kann (Art. 60 DSG)."
+    "legal_reference": "Gemäss Art. 18 der Verordnung über den Datenschutz (Datenschutzverordnung, DSV) vom 31. August 2022 müssen die Auskunft oder die Information über eine verzögerte Auskunft innerhalb von 30 Tagen erfolgen. Ebenfalls innerhalb von 30 Tagen muss mitgeteilt werden, wenn die Auskunft verweigert oder aufgeschoben wird.",
+    "enforcement": "Ich bitte Sie entsprechend, die Auskunft zu erteilen. Sollten Sie weiterhin keine Auskunft erteilen, behalte ich mir jederzeit vor, mein Auskunftsrecht auf dem Rechtsweg durchzusetzen oder Anzeige beim Eidgenössischen Datenschutz- und Öffentlichkeitsbeauftragten (EDÖB) zu erstatten.  Ich weise ausserdem vorsorglich darauf hin, dass das vorsätzliche Erteilen einer falschen oder unvollständigen Auskunft auf Antrag mit Busse bis zu 250'000 Franken bestraft werden kann (Art. 60 DSG)."
   }
 }

--- a/src/locales/fr-CH.letter.json
+++ b/src/locales/fr-CH.letter.json
@@ -11,7 +11,7 @@
   "data_info_request": "Requête de données traitées",
   "salutation": "Chère Madame, cher Monsieur,",
   "letter": {
-    "initial_request": "Je vous prie de m'indiquer dans un délai de 30 jours si des données me concernant on fait l'objet d'un traitement. Cette demande est fondée sur l'art. 25 de la Loi fédérale sur la protection des données (LPD) du 25 septembre 2020.",
+    "initial_request": "Je vous prie de m'indiquer dans un délai de 30 jours si des données me concernant on fait l'objet d'un traitement. Cette demande est fondée sur l'art. 25 de la Loi fédérale sur la protection des données (LPD) du 25 septembre 2020.",
     "info_requirement": "Dans la mesure où des données me concernant ont fait l'objet d'un traitement, je vous prie de me communiquer les informations pertinentes pour me permettre d'exercer mes droits selon la LPD et pour garantir la transparence dans le traitement de mes données.",
     "request_info_list": "Je vous sollicite dans ce cadre de me transmettre les informations suivantes:",
     "list_item_1": "L'identité et les données de contact de tous les responsables",
@@ -28,7 +28,7 @@
   },
   "closing": "Je vous remercie et vous adresse mes meilleures salutations",
   "attachment_official_id": "En annexe: Pièce d'identité (copie)",
-  "data_access_request": "Requête en renseignement sur les données personnelles",
+  "letter_info_req_change_subject": "Requête en droit d'accès / Rectification",
   "thank_you_message_pre": "Je vous remercie pour vos précisions du ",
   "thank_you_message_post": ".",
   "letter_change_body_1_continuation": "J'en constate que les données personnelles qui ont fait l'objet d'un traitement auprès de vous ne sont pas correctes.",
@@ -36,7 +36,7 @@
   "letter_change_list_item": "[Listes des données à corriger et des modifications souhaitées]",
   "letter_change_body_3": "Je vous prie également d'informer les tiers auprès desquels vous avez reçu les données incorrectes ou les tiers auxquels vous les avez transmis de cette correction.",
   "letter_change_body_4": "Je vous prie finalement de confirmer la correction.",
-  "data_disclosure_request": "Requête en renseignement de données",
+  "letter_info_req_delete_subject": "Requête en droit d'accès / Suppression",
   "deletion_request_message": "Je vous prie, sur la base de vos renseignements, de supprimer les données personnelles suivantes:",
   "deletion_list_placeholder": "[Liste des données à supprimer ou toutes les données]",
   "inform_third_parties_message": "Je vous prie également d'informer les tiers auprès desquels vous avez reçu les données incorrectes ou les tiers auxquels vous les avez transmis de cette suppression.",
@@ -46,13 +46,14 @@
   "letter_info_req_demand_incomplete_post": ".",
   "letter_info_req_demand_missing_info": "Je considère manquantes notamment les informations suivantes:",
   "letter_info_req_demand_list_missing": "[Liste des données manquantes]",
-  "letter_info_req_demand_refusal": "Je vous prie de m'indiquer les raisons justifiant la restriction de ces informations. Cette obligation vous incombe en vertu de l'art. 18 oLPD (Ordonnance sur la protection des données)",
-  "letter_info_req_demand_enforcement": "Je me réserve le droit, sans renseignements complets de votre part, d'entâmer des démarches afin de faire reconnaitre mon droit à l'information par la voie judiciaire ou de signaler le cas au Préposé fédéral à la protection des données et à la transparence (PFPDT). Je vous rends également attentif au fait que la communication intentionnelle d'informations fausses ou incomplètes est puni sur plaine d'une amende allant jusqu'à 250'000 Francs (Art. 60 LPD).",
+  "letter_info_req_demand_subject": "Requête en droit d'accès / Renseignement incomplet",
+  "letter_info_req_demand_refusal": "Je vous prie de m'indiquer les raisons justifiant la restriction de ces informations. Cette obligation vous incombe en vertu de l'art. 18 oLPD (Ordonnance sur la protection des données)",
+  "letter_info_req_demand_enforcement": "Je me réserve le droit, sans renseignements complets de votre part, d'entâmer des démarches afin de faire reconnaitre mon droit à l'information par la voie judiciaire ou de signaler le cas au Préposé fédéral à la protection des données et à la transparence (PFPDT). Je vous rends également attentif au fait que la communication intentionnelle d'informations fausses ou incomplètes est puni sur plaine d'une amende allant jusqu'à 250'000 Francs (Art. 60 LPD).",
   "letter_info_req_remind": {
     "subject": "Requête en droit d'accès / Renseignement manquant",
     "unanswered_request_pre": "J'ai formulé le ",
     "unanswered_request_post": " une demande d'accès à mes données personnelles, qui est restée sans réponse.",
-    "legal_reference": "Les renseignements demandés ou un éventuel retard dans leur réédition doivent être communiqués dans les 30 jours à compter du dépôt de la requête (art. 18 oLPD [Ordonnance sur la protection des donnnées]). Ce délai vaut également pour annoncer un refus ou une restriction.",
-    "enforcement": "Je vous prie donc de me fournir les renseignements demandés. Je me réserve le droit, sans réponse de votre part, d'entâmer des démarches afin de faire reconnaitre mon droit à l'information par la voie judiciaire ou de signaler le cas au Préposé fédéral à la protection des données et à la transparence (PFPDT). Je vous rends également attentif au fait que la communication intentionnelle d'informations fausses ou incomplètes est puni sur plaine d'une amende allant jusqu'à 250'000 Francs (Art. 60 LPD)."
+    "legal_reference": "Les renseignements demandés ou un éventuel retard dans leur réédition doivent être communiqués dans les 30 jours à compter du dépôt de la requête (art. 18 oLPD [Ordonnance sur la protection des donnnées]). Ce délai vaut également pour annoncer un refus ou une restriction.",
+    "enforcement": "Je vous prie donc de me fournir les renseignements demandés. Je me réserve le droit, sans réponse de votre part, d'entâmer des démarches afin de faire reconnaitre mon droit à l'information par la voie judiciaire ou de signaler le cas au Préposé fédéral à la protection des données et à la transparence (PFPDT). Je vous rends également attentif au fait que la communication intentionnelle d'informations fausses ou incomplètes est puni sur plaine d'une amende allant jusqu'à 250'000 Francs (Art. 60 LPD)."
   }
 }


### PR DESCRIPTION
…s own subject

The dates and article references in the letters were written with normal spaces, so a line could break right after "31.", "25." or "Art.". Day, month and year as well as abbreviation, article number and law abbreviation are now joined with non-breaking spaces (U+00A0) in the German and French letter texts and in the component defaults.

The follow-up letters for an incomplete answer, a correction and a deletion all carried the generic subject "Datenauskunftsbegehren". Each now has its own key, mirroring the existing "Ausbleibende Auskunft" letter:

- letter_info_req_demand_subject — "Datenauskunftsbegehren / Unvollständige Auskunft"
- letter_info_req_change_subject — "Datenauskunftsbegehren / Berichtigung"
- letter_info_req_delete_subject — "Datenauskunftsbegehren / Löschung"

The now unused keys data_access_request and data_disclosure_request were removed from both letter locale files.

Playwright tests cover the protected citations in the initial, remind and demand letters (German and French) and the three new subject lines.

Closes #195